### PR TITLE
OrderList Enhancements & DepositNative bug fix

### DIFF
--- a/contracts/OrderBooks.sol
+++ b/contracts/OrderBooks.sol
@@ -29,7 +29,7 @@ contract OrderBooks is Initializable, AccessControlEnumerableUpgradeable {
     using RBTLibrary for RBTLibrary.Tree;
     using Bytes32LinkedListLibrary for Bytes32LinkedListLibrary.LinkedList;
     // version
-    bytes32 public constant VERSION = bytes32("2.2.0");
+    bytes32 public constant VERSION = bytes32("2.2.1");
 
     // orderbook structure defining one sell or buy book
     struct OrderBook {
@@ -221,7 +221,7 @@ contract OrderBooks is Initializable, AccessControlEnumerableUpgradeable {
         (, , , , , bytes32 head, uint256 size) = this.getNode(_orderBookID, _price);
         uint256[] memory quantities = new uint256[](size);
         OrderBook storage orderBook = orderBookMap[_orderBookID];
-        for (uint256 i = 0; i < size; i++) {
+        for (uint256 i = 0; i < size; ++i) {
             quantities[i] = tradePairs.getOrderRemainingQuantity(head);
             (, head) = orderBook.orderList[_price].getAdjacent(head, false);
         }
@@ -279,7 +279,7 @@ contract OrderBooks is Initializable, AccessControlEnumerableUpgradeable {
         uint256 price = first(_orderBookID);
         uint256 i;
         while (price > 0) {
-            i++;
+            ++i;
             price = next(_orderBookID, price);
         }
         return i;
@@ -334,7 +334,7 @@ contract OrderBooks is Initializable, AccessControlEnumerableUpgradeable {
             _lastPrice = (side == ITradePairs.Side.SELL)
                 ? next(_orderBookID, _lastPrice)
                 : prev(_orderBookID, _lastPrice);
-            i++;
+            ++i;
         }
         return (prices, quantities, _lastPrice, _lastOrder);
     }
@@ -369,7 +369,7 @@ contract OrderBooks is Initializable, AccessControlEnumerableUpgradeable {
                 quantities[i] += tradePairs.getOrderRemainingQuantity(a);
                 (ex, a) = orderBook.orderList[price].getAdjacent(a, true);
             }
-            i++;
+            ++i;
             price = (_type == 0) ? next(_orderBookID, price) : prev(_orderBookID, price);
         }
         return (prices, quantities);

--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -32,7 +32,7 @@ import "./interfaces/IPortfolioBridge.sol";
  * If your trading application has a business need to deposit/withdraw more often, then your app
  * will need to integrate with the PortfolioMain contract in the mainnet as well to fully automate
  * your flow.
- * ExchangeSub needs to have DEFAULT_ADMIN_ROLE on this contract.
+ * Exchange needs to have DEFAULT_ADMIN_ROLE on this contract.
  */
 
 // The code in this file is part of Dexalot project.
@@ -188,18 +188,14 @@ abstract contract Portfolio is
 
     /**
      * @notice  Sets the bridge provider fee & gasSwapRatio per ALOT for the given token and usedForGasSwap flag
-     * @dev     External function to be called by ADMIN
+     * @dev     External function to be called by DEFAULT_ADMIN_ROLE or PORTFOLIO_BRIDGE_ROLE
      * @param   _symbol  Symbol of the token
      * @param   _fee  Fee to be set
      * @param   _gasSwapRatio  Amount of token to swap per ALOT. Always set it to equivalent of 1 ALOT.
      * @param   _usedForGasSwap  bool to control the list of tokens that can be used for gas swap. Mostly majors
      */
-    function setBridgeParam(
-        bytes32 _symbol,
-        uint256 _fee,
-        uint256 _gasSwapRatio,
-        bool _usedForGasSwap
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setBridgeParam(bytes32 _symbol, uint256 _fee, uint256 _gasSwapRatio, bool _usedForGasSwap) external {
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender) || hasRole(PORTFOLIO_BRIDGE_ROLE, msg.sender), "P-OACC-01");
         setBridgeParamInternal(_symbol, _fee, _gasSwapRatio, _usedForGasSwap);
     }
 
@@ -323,7 +319,7 @@ abstract contract Portfolio is
      */
     function getTokenList() external view override returns (bytes32[] memory) {
         bytes32[] memory tokens = new bytes32[](tokenList.length());
-        for (uint256 i = 0; i < tokenList.length(); i++) {
+        for (uint256 i = 0; i < tokenList.length(); ++i) {
             tokens[i] = tokenList.at(i);
         }
         return tokens;

--- a/contracts/PortfolioBridge.sol
+++ b/contracts/PortfolioBridge.sol
@@ -66,7 +66,7 @@ contract PortfolioBridge is Initializable, PausableUpgradeable, ReentrancyGuardU
 
     // solhint-disable-next-line func-name-mixedcase
     function VERSION() public pure virtual override returns (bytes32) {
-        return bytes32("2.2.0");
+        return bytes32("2.2.1");
     }
 
     /**
@@ -166,6 +166,23 @@ contract PortfolioBridge is Initializable, PausableUpgradeable, ReentrancyGuardU
         portfolio = IPortfolio(_portfolio);
         grantRole(PORTFOLIO_ROLE, _portfolio);
         addNativeToken();
+    }
+
+    /**
+     * @notice  Sets the bridge provider fee & gasSwapRatio per ALOT for the given token and usedForGasSwap flag
+     * @dev     External function to be called by BRIDGE_ADMIN_ROLE
+     * @param   _symbol  Symbol of the token
+     * @param   _fee  Fee to be set
+     * @param   _gasSwapRatio  Amount of token to swap per ALOT. Always set it to equivalent of 1 ALOT.
+     * @param   _usedForGasSwap  bool to control the list of tokens that can be used for gas swap. Mostly majors
+     */
+    function setBridgeParam(
+        bytes32 _symbol,
+        uint256 _fee,
+        uint256 _gasSwapRatio,
+        bool _usedForGasSwap
+    ) external onlyRole(BRIDGE_ADMIN_ROLE) {
+        portfolio.setBridgeParam(_symbol, _fee, _gasSwapRatio, _usedForGasSwap);
     }
 
     /**
@@ -460,7 +477,7 @@ contract PortfolioBridge is Initializable, PausableUpgradeable, ReentrancyGuardU
      * @param   _tokens  Array of ERC20 tokens to refund
      */
     function refundTokens(address[] calldata _tokens) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        for (uint256 i = 0; i < _tokens.length; i++) {
+        for (uint256 i = 0; i < _tokens.length; ++i) {
             IERC20Upgradeable(_tokens[i]).transfer(msg.sender, IERC20Upgradeable(_tokens[i]).balanceOf(address(this)));
         }
     }

--- a/contracts/PortfolioBridgeSub.sol
+++ b/contracts/PortfolioBridgeSub.sol
@@ -60,7 +60,7 @@ contract PortfolioBridgeSub is PortfolioBridge, IPortfolioBridgeSub {
 
     // solhint-disable-next-line func-name-mixedcase
     function VERSION() public pure override returns (bytes32) {
-        return bytes32("2.2.1");
+        return bytes32("2.2.2");
     }
 
     /**
@@ -214,7 +214,7 @@ contract PortfolioBridgeSub is PortfolioBridge, IPortfolioBridgeSub {
      */
     function getTokenList() external view override returns (bytes32[] memory) {
         bytes32[] memory tokens = new bytes32[](tokenListById.length());
-        for (uint256 i = 0; i < tokenListById.length(); i++) {
+        for (uint256 i = 0; i < tokenListById.length(); ++i) {
             tokens[i] = tokenListById.at(i);
         }
         return tokens;
@@ -273,7 +273,7 @@ contract PortfolioBridgeSub is PortfolioBridge, IPortfolioBridgeSub {
         uint256[] calldata _thresholds
     ) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_tokens.length == _thresholds.length, "PB-LENM-01");
-        for (uint256 i = 0; i < _tokens.length; i++) {
+        for (uint256 i = 0; i < _tokens.length; ++i) {
             delayThresholds[_tokens[i]] = _thresholds[i];
             emit DelayThresholdUpdated(_tokens[i], _thresholds[i]);
         }
@@ -341,7 +341,7 @@ contract PortfolioBridgeSub is PortfolioBridge, IPortfolioBridgeSub {
         uint256[] calldata _caps
     ) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_tokens.length == _caps.length, "PB-LENM-02");
-        for (uint256 i = 0; i < _tokens.length; i++) {
+        for (uint256 i = 0; i < _tokens.length; ++i) {
             epochVolumeCaps[_tokens[i]] = _caps[i];
             emit EpochVolumeUpdated(_tokens[i], _caps[i]);
         }

--- a/contracts/PortfolioMain.sol
+++ b/contracts/PortfolioMain.sol
@@ -25,7 +25,7 @@ contract PortfolioMain is Portfolio, IPortfolioMain {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     // version
-    bytes32 public constant VERSION = bytes32("2.2.0");
+    bytes32 public constant VERSION = bytes32("2.2.1");
 
     // bytes32 symbols to ERC20 token map
     mapping(bytes32 => IERC20Upgradeable) public tokenMap;
@@ -231,7 +231,7 @@ contract PortfolioMain is Portfolio, IPortfolioMain {
         bytes32[] memory tokens = new bytes32[](tokenList.length());
         uint256[] memory amounts = new uint256[](tokenList.length());
 
-        for (uint256 i = 0; i < tokenList.length(); i++) {
+        for (uint256 i = 0; i < tokenList.length(); ++i) {
             BridgeParams storage bridgeParam = bridgeParams[tokenList.at(i)];
             tokens[i] = tokenList.at(i);
             amounts[i] = ((bridgeParam.fee + bridgeParam.gasSwapRatio) * minDepositMultiplier) / 10;
@@ -345,7 +345,7 @@ contract PortfolioMain is Portfolio, IPortfolioMain {
      * @param   _symbols  Array of symbols of tokens to withdraw
      */
     function collectBridgeFees(bytes32[] calldata _symbols) external nonReentrant onlyRole(DEFAULT_ADMIN_ROLE) {
-        for (uint256 i = 0; i < _symbols.length; i++) {
+        for (uint256 i = 0; i < _symbols.length; ++i) {
             require(tokenList.contains(_symbols[i]), "P-ETNS-02");
             uint256 bcf = bridgeFeeCollected[_symbols[i]];
             if (bcf > 0) {

--- a/contracts/PortfolioSub.sol
+++ b/contracts/PortfolioSub.sol
@@ -64,12 +64,6 @@ contract PortfolioSub is Portfolio, IPortfolioSub {
     address public feeAddress;
     bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
 
-    enum AssetType {
-        NATIVE,
-        ERC20,
-        NONE
-    }
-
     // keep track of deposited and burned native tokens
     uint256 public totalNativeBurned;
 
@@ -224,7 +218,7 @@ contract PortfolioSub is Portfolio, IPortfolioSub {
     function getBalance(
         address _owner,
         bytes32 _symbol
-    ) external view returns (uint256 total, uint256 available, AssetType assetType) {
+    ) external view override returns (uint256 total, uint256 available, AssetType assetType) {
         assetType = AssetType.NONE;
         if (native == _symbol) {
             assetType = AssetType.NATIVE;
@@ -608,7 +602,11 @@ contract PortfolioSub is Portfolio, IPortfolioSub {
      * @param   _symbol  Symbol of the token
      * @param   _quantity  Amount of the token
      */
-    function transferToken(address _to, bytes32 _symbol, uint256 _quantity) external whenNotPaused nonReentrant {
+    function transferToken(
+        address _to,
+        bytes32 _symbol,
+        uint256 _quantity
+    ) external override whenNotPaused nonReentrant {
         require(tokenList.contains(_symbol), "P-ETNS-01");
         require(_to != msg.sender, "P-DOTS-01");
         //Can not transfer auction tokens
@@ -655,7 +653,7 @@ contract PortfolioSub is Portfolio, IPortfolioSub {
                 _maxCount--;
             }
             unchecked {
-                i++;
+                ++i;
             }
             if (i == tokenCount) {
                 _maxCount = 0;

--- a/contracts/PortfolioSub.sol
+++ b/contracts/PortfolioSub.sol
@@ -74,7 +74,7 @@ contract PortfolioSub is Portfolio, IPortfolioSub {
     uint256 public totalNativeBurned;
 
     // version
-    bytes32 public constant VERSION = bytes32("2.2.1");
+    bytes32 public constant VERSION = bytes32("2.2.2");
 
     /**
      * @notice  Initializer for upgradeable Portfolio Sub
@@ -396,14 +396,13 @@ contract PortfolioSub is Portfolio, IPortfolioSub {
     ) external payable override whenNotPaused nonReentrant {
         require(_from == msg.sender || msg.sender == address(this), "P-OOWN-02"); // calls made by super.receive()
         require(allowDeposit, "P-NTDP-01");
-        // the ending balance cannot be lower than the twice the gasAmount that we would deposit. Currently 0.1*2 ALOT
-        require(_from.balance >= msg.value + (gasStation.gasAmount() * 2), "P-BLTH-01");
-
         // We burn the deposit amount but still credit the user account because we minted the ALOT with withdrawNative
         // solhint-disable-next-line avoid-low-level-calls
         (bool sent, ) = address(0).call{value: msg.value}("");
         require(sent, "P-BF-01");
-
+        // the ending balance cannot be lower than the twice the gasAmount that we would deposit
+        // using autoFill. Currently 0.1*2= 0.2 ALOT
+        require(_from.balance >= gasStation.gasAmount() * 2, "P-BLTH-01");
         totalNativeBurned += msg.value;
         safeIncrease(_from, native, msg.value, 0, Tx.REMOVEGAS);
     }

--- a/contracts/TradePairs.sol
+++ b/contracts/TradePairs.sol
@@ -37,7 +37,7 @@ contract TradePairs is
     using EnumerableSetUpgradeable for EnumerableSetUpgradeable.UintSet;
 
     // version
-    bytes32 public constant VERSION = bytes32("2.2.2");
+    bytes32 public constant VERSION = bytes32("2.2.3");
 
     // denominator for rate calculations
     uint256 public constant TENK = 10000;
@@ -331,7 +331,7 @@ contract TradePairs is
         TradePair storage tradePair = tradePairMap[_tradePairId];
         uint256 oldValue = uint256(tradePair.auctionMode);
         tradePair.auctionMode = _mode;
-        IPortfolioSub(address(portfolio)).setAuctionMode(tradePair.baseSymbol, _mode);
+        portfolio.setAuctionMode(tradePair.baseSymbol, _mode);
         if (UtilsLibrary.matchingAllowed(_mode)) {
             // Makes sure that the matching is completed after the auction has ended and order book
             // doesn't have any crossed orders left before unpausing the trade pair

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -51,6 +51,8 @@ interface IPortfolio {
 
     function getTokenList() external view returns (bytes32[] memory);
 
+    function setBridgeParam(bytes32 _symbol, uint256 _fee, uint256 _gasSwapRatio, bool _usedForGasSwap) external;
+
     event PortfolioUpdated(
         Tx indexed transaction,
         address indexed wallet,

--- a/contracts/interfaces/IPortfolioSub.sol
+++ b/contracts/interfaces/IPortfolioSub.sol
@@ -29,6 +29,19 @@ interface IPortfolioSub {
         uint256 _takerfeeCharged
     ) external;
 
+    function transferToken(address _to, bytes32 _symbol, uint256 _quantity) external;
+
+    enum AssetType {
+        NATIVE,
+        ERC20,
+        NONE
+    }
+
+    function getBalance(
+        address _owner,
+        bytes32 _symbol
+    ) external view returns (uint256 total, uint256 available, AssetType assetType);
+
     function withdrawNative(address payable _to, uint256 _quantity) external;
 
     function withdrawToken(

--- a/contracts/interfaces/ITradePairs.sol
+++ b/contracts/interfaces/ITradePairs.sol
@@ -158,7 +158,7 @@ interface ITradePairs {
 
     function cancelOrder(bytes32 _orderId) external;
 
-    function cancelAllOrders(bytes32[] memory _orderIds) external;
+    function cancelOrderList(bytes32[] memory _orderIds) external;
 
     function cancelReplaceOrder(bytes32 _orderId, bytes32 _clientOrderId, uint256 _price, uint256 _quantity) external;
 
@@ -204,12 +204,14 @@ interface ITradePairs {
      * @notice  Order Status
      * @dev     And order automatically gets the NEW status once it is committed to the blockchain \
      * 0: NEW      – Order is in the orderbook with no trades/executions \
-     * 1: REJECTED – For future use \
+     * 1: REJECTED – Order is rejected. Currently used addLimitOrderList to notify when an order from the list is
+     * rejected instead of reverting the entire order list \
      * 2: PARTIAL  – Order filled partially and it remains in the orderbook until FILLED/CANCELED \
      * 3: FILLED   – Order filled fully and removed from the orderbook \
      * 4: CANCELED – Order canceled and removed from the orderbook. PARTIAL before CANCELED is allowed \
      * 5: EXPIRED  – For future use \
-     * 6: KILLED   – For future use
+     * 6: KILLED   – For future use \
+     * 7: CANCEL_REJECT   – Cancel Request Rejected with reason code
      */
     enum Status {
         NEW,
@@ -218,7 +220,8 @@ interface ITradePairs {
         FILLED,
         CANCELED,
         EXPIRED,
-        KILLED
+        KILLED,
+        CANCEL_REJECT
     }
     /**
      * @notice  Rate Type
@@ -334,7 +337,8 @@ interface ITradePairs {
         Type2 type2,
         Status status,
         uint256 quantityfilled,
-        uint256 totalfee
+        uint256 totalfee,
+        bytes32 code
     );
 
     /**
@@ -371,6 +375,5 @@ interface ITradePairs {
         address indexed addressMaker,
         address indexed addressTaker
     );
-
     event ParameterUpdated(uint8 version, bytes32 indexed pair, string param, uint256 oldValue, uint256 newValue);
 }

--- a/contracts/library/UtilsLibrary.sol
+++ b/contracts/library/UtilsLibrary.sol
@@ -102,10 +102,10 @@ library UtilsLibrary {
     function bytes32ToString(bytes32 _bytes32) internal pure returns (string memory) {
         uint8 i = 0;
         while (i < 32 && _bytes32[i] != 0) {
-            i++;
+            ++i;
         }
         bytes memory bytesArray = new bytes(i);
-        for (i = 0; i < 32 && _bytes32[i] != 0; i++) {
+        for (i = 0; i < 32 && _bytes32[i] != 0; ++i) {
             bytesArray[i] = _bytes32[i];
         }
         return string(bytesArray);

--- a/contracts/token/IncentiveDistributor.sol
+++ b/contracts/token/IncentiveDistributor.sol
@@ -9,6 +9,8 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 
+import "../interfaces/IPortfolioSub.sol";
+
 /**
  * @title Distributor for Dexalot Incentive Program (DIP) rewards
  * @notice IncentiveDistributor distributes 200,000 $ALOT tokens monthly for up to 2 years and
@@ -16,7 +18,7 @@ import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable
  * trader are calculated off-chain and finalized at month's end. To validate, we sign a
  * message containing the trader address, ids and amounts of reward tokens earned to date.
  * This signature is input to the claim function to verify and allow traders to withdraw
- * their earned Dexalot Incentive Program (DIP) rewards.
+ * their earned Dexalot Incentive Program (DIP) rewards to the PortfolioSubnet contract.
  */
 
 // The code in this file is part of Dexalot project.
@@ -24,43 +26,48 @@ import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable
 // Copyright 2022 Dexalot.
 
 contract IncentiveDistributor is PausableUpgradeable, OwnableUpgradeable, EIP712Upgradeable {
-    using SafeERC20Upgradeable for IERC20Upgradeable;
-
     // version
-    bytes32 public constant VERSION = bytes32("1.0.0");
+    bytes32 public constant VERSION = bytes32("1.0.1");
+
+    IPortfolioSub private _portfolio;
 
     // bitmap representing current reward tokenIds
     uint32 public allTokens;
     address private _signer;
-    mapping(uint32 => IERC20Upgradeable) public tokens;
+    mapping(uint32 => bytes32) public tokens;
     mapping(address => mapping(uint32 => uint128)) public claimedRewards;
 
     event Claimed(address indexed claimer, uint32 tokenIds, uint128[] amounts, uint256 timestamp);
-    event AddRewardToken(IERC20Upgradeable token, uint32 tokenId, uint256 timestamp);
+    event AddRewardToken(bytes32 symbol, uint32 tokenId, uint256 timestamp);
+    event DepositGas(address from, uint256 quantity, uint256 timestamp);
+    event WithdrawGas(address to, uint256 quantity, uint256 timestamp);
 
     /**
      * @notice Initializer of the IncentiveDistributor
      * @dev    Adds ALOT token as the first reward token and defines the signer of claim messages.
-     * @param  _alotToken The address of the ALOT token
+     * @param  _alotSymbol The symbol of the ALOT token
      * @param  __signer The public address of the signer of claim messages
+     * @param __portfolio The address of the portfolio sub contract
      */
-    function initialize(IERC20Upgradeable _alotToken, address __signer) public initializer {
+    function initialize(bytes32 _alotSymbol, address __signer, address __portfolio) public initializer {
         __Ownable_init();
         __Pausable_init();
-        __EIP712_init("Dexalot", "1.0.0");
+        __EIP712_init("Dexalot", "1.0.1");
 
         require(__signer != address(0), "ID-ZADDR-01");
+        require(__portfolio != address(0), "ID-ZADDR-02");
 
         uint32 tokenId = ~allTokens & (allTokens + 1);
-        tokens[tokenId] = _alotToken;
+        tokens[tokenId] = _alotSymbol;
         allTokens |= tokenId;
         _signer = __signer;
+        _portfolio = IPortfolioSub(__portfolio);
 
-        emit AddRewardToken(_alotToken, tokenId, block.timestamp);
+        emit AddRewardToken(_alotSymbol, tokenId, block.timestamp);
     }
 
     /**
-     * @notice Claim DIP token rewards for a given trader
+     * @notice Claim DIP token rewards for a given trader in their portfolio
      * @param  _amounts An array of total earned amount for each reward token
      * @param  _tokenIds A bitmap representing which tokens to claim
      * @param  _signature A signed claim message to be verified
@@ -71,7 +78,7 @@ contract IncentiveDistributor is PausableUpgradeable, OwnableUpgradeable, EIP712
 
         bool isClaimed;
 
-        for (uint8 i = 0; i < _amounts.length; i++) {
+        for (uint256 i = 0; i < _amounts.length; ++i) {
             require(_tokenIds != 0, "ID-TACM-01");
             uint32 tokenId = _tokenIds & ~(_tokenIds - 1);
             _tokenIds -= tokenId;
@@ -81,12 +88,11 @@ contract IncentiveDistributor is PausableUpgradeable, OwnableUpgradeable, EIP712
             require(amount >= prevClaimed, "ID-RTPC-01");
 
             if (amount != prevClaimed) {
-                IERC20Upgradeable token = tokens[tokenId];
+                bytes32 symbol = tokens[tokenId];
                 uint128 claimableAmount = amount - prevClaimed;
-                require(token.balanceOf(address(this)) >= claimableAmount, "ID-RTBI-01");
 
+                _portfolio.transferToken(msg.sender, symbol, claimableAmount);
                 claimedRewards[msg.sender][tokenId] += claimableAmount;
-                token.safeTransfer(msg.sender, claimableAmount);
 
                 _amounts[i] = claimableAmount;
                 isClaimed = true;
@@ -123,14 +129,14 @@ contract IncentiveDistributor is PausableUpgradeable, OwnableUpgradeable, EIP712
 
     /**
      * @notice Add new claimable reward token
-     * @param  _rewardToken The address of the new reward token
+     * @param  _symbol The symbol of the new reward token
      */
-    function addRewardToken(IERC20Upgradeable _rewardToken) external whenPaused onlyOwner {
+    function addRewardToken(bytes32 _symbol) external whenPaused onlyOwner {
         uint32 tokenId = ~allTokens & (allTokens + 1);
-        tokens[tokenId] = _rewardToken;
+        tokens[tokenId] = _symbol;
         allTokens |= tokenId;
 
-        emit AddRewardToken(_rewardToken, tokenId, block.timestamp);
+        emit AddRewardToken(_symbol, tokenId, block.timestamp);
     }
 
     /**
@@ -138,11 +144,11 @@ contract IncentiveDistributor is PausableUpgradeable, OwnableUpgradeable, EIP712
      * @param  _tokenId The id of the reward token to retrieve
      */
     function retrieveRewardToken(uint32 _tokenId) external whenPaused onlyOwner {
-        IERC20Upgradeable token = tokens[_tokenId];
-        require(address(token) != address(0), "ID-TDNE-02");
+        bytes32 symbol = tokens[_tokenId];
+        require(symbol != bytes32(0), "ID-TDNE-02");
 
-        uint256 balance = token.balanceOf(address(this));
-        token.safeTransfer(msg.sender, balance);
+        (, uint256 availableBalance, ) = _portfolio.getBalance(address(this), symbol);
+        _portfolio.transferToken(msg.sender, symbol, availableBalance);
     }
 
     /**
@@ -150,10 +156,27 @@ contract IncentiveDistributor is PausableUpgradeable, OwnableUpgradeable, EIP712
      */
     function retrieveAllRewardTokens() external whenPaused onlyOwner {
         for (uint32 tokenId = 1; tokenId < allTokens; tokenId <<= 1) {
-            IERC20Upgradeable token = tokens[tokenId];
-            uint256 balance = token.balanceOf(address(this));
-            token.safeTransfer(msg.sender, balance);
+            bytes32 symbol = tokens[tokenId];
+            (, uint256 availableBalance, ) = _portfolio.getBalance(address(this), symbol);
+            _portfolio.transferToken(msg.sender, symbol, availableBalance);
         }
+    }
+
+    /**
+     * @notice Receive native ALOT, ensures auto gas tank fill logic holds
+     */
+    receive() external payable {
+        emit DepositGas(msg.sender, msg.value, block.timestamp);
+    }
+
+    /**
+     * @notice Withdraw ALOT from IncentiveDistributor gas tank to owner
+     * @param amount The amount of ALOT to withdraw to owner
+     */
+    function withdrawGas(uint256 amount) external onlyOwner {
+        require(address(this).balance >= amount, "ID-AGCB-01");
+        emit WithdrawGas(msg.sender, amount, block.timestamp);
+        payable(msg.sender).transfer(amount);
     }
 
     /**

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,20 +1,20 @@
 --------------------------------------|----------|----------|----------|----------|----------------|
 File                                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 --------------------------------------|----------|----------|----------|----------|----------------|
- contracts\                           |      100 |    94.87 |      100 |      100 |                |
+ contracts\                           |      100 |       95 |      100 |      100 |                |
   BannedAccounts.sol                  |      100 |      100 |      100 |      100 |                |
   Exchange.sol                        |      100 |      100 |      100 |      100 |                |
   ExchangeMain.sol                    |      100 |      100 |      100 |      100 |                |
   ExchangeSub.sol                     |      100 |      100 |      100 |      100 |                |
   GasStation.sol                      |      100 |    93.33 |      100 |      100 |                |
   OrderBooks.sol                      |      100 |      100 |      100 |      100 |                |
-  Portfolio.sol                       |      100 |    95.65 |      100 |      100 |                |
-  PortfolioBridge.sol                 |      100 |    90.91 |      100 |      100 |                |
+  Portfolio.sol                       |      100 |    95.83 |      100 |      100 |                |
+  PortfolioBridge.sol                 |      100 |    91.18 |      100 |      100 |                |
   PortfolioBridgeSub.sol              |      100 |    91.94 |      100 |      100 |                |
   PortfolioMain.sol                   |      100 |     91.3 |      100 |      100 |                |
   PortfolioMinter.sol                 |      100 |      100 |      100 |      100 |                |
-  PortfolioSub.sol                    |      100 |    93.13 |      100 |      100 |                |
-  TradePairs.sol                      |      100 |    95.58 |      100 |      100 |                |
+  PortfolioSub.sol                    |      100 |    93.75 |      100 |      100 |                |
+  TradePairs.sol                      |      100 |    95.54 |      100 |      100 |                |
  contracts\bridgeApps\                |      100 |      100 |      100 |      100 |                |
   LzApp.sol                           |      100 |      100 |      100 |      100 |                |
  contracts\interfaces\                |      100 |      100 |      100 |      100 |                |
@@ -38,7 +38,7 @@ File                                  |  % Stmts | % Branch |  % Funcs |  % Line
   UtilsLibrary.sol                    |      100 |      100 |      100 |      100 |                |
  contracts\others\                    |      100 |      100 |      100 |      100 |                |
   Multicall2.sol                      |      100 |      100 |      100 |      100 |                |
- contracts\token\                     |      100 |    95.91 |      100 |      100 |                |
+ contracts\token\                     |      100 |    95.98 |      100 |      100 |                |
   Airdrop.sol                         |      100 |      100 |      100 |      100 |                |
   DexalotToken.sol                    |      100 |      100 |      100 |      100 |                |
   IncentiveDistributor.sol            |      100 |      100 |      100 |      100 |                |
@@ -47,5 +47,5 @@ File                                  |  % Stmts | % Branch |  % Funcs |  % Line
   TokenVestingCloneFactory.sol        |      100 |      100 |      100 |      100 |                |
   TokenVestingCloneable.sol           |      100 |    96.67 |      100 |      100 |                |
 --------------------------------------|----------|----------|----------|----------|----------------|
-All files                             |      100 |    95.56 |      100 |      100 |                |
+All files                             |      100 |    95.66 |      100 |      100 |                |
 --------------------------------------|----------|----------|----------|----------|----------------|

--- a/errors.json
+++ b/errors.json
@@ -92,7 +92,7 @@
     "T-CQFA-01": "TradePairs: change to quantityFilled already applied",
     "T-PPAU-01": "TradePairs: Pair paused",
     "T-PPAU-02": "TradePairs: cancelOrder pair paused",
-    "T-PPAU-03": "TradePairs: cancelAllOrders pair paused",
+    "T-PPAU-03": "TradePairs: cancelOrderList pair paused",
     "T-PPAU-04": "TradePairs: Pair should be paused for this operation",
     "T-AOPA-01": "TradePairs: addOrderPaused paused",
     "T-IVOT-01": "TradePairs: invalid order type",
@@ -214,14 +214,15 @@
     "TVC-TKNR-01": "TokenVestingCloneable: token not revoked",
 
     "ID-ZADDR-01": "IncentiveDistributor: cannot initialize signer with zero address(0)",
+    "ID-ZADDR-02": "IncentiveDistributor: cannot initialize portfolio with zero address(0)",
     "ID-TDNE-01": "IncentiveDistributor: tokenId does not exist",
     "ID-TDNE-02": "IncentiveDistributor: tokenId does not exist",
     "ID-SIGN-01": "IncentiveDistributor: invalid claim inputs, user, tokenId, amounts or signer does not match signature",
     "ID-RTPC-01": "IncentiveDistributor: reward tokens previously claimed",
     "ID-NTTC-01": "IncentiveDistributor: no reward tokens to claim",
-    "ID-RTBI-01": "IncentiveDistributor: reward token balance insufficient in contract",
     "ID-TACM-01": "IncentiveDistributor: number of tokens and claim amounts mismatch, no. of tokens less than no. of claims",
     "ID-TACM-02": "IncentiveDistributor: number of tokens and claim amounts mismatch, no. of tokens greater than no. of claims",
+    "ID-AGCB-01": "IncentiveDistributor: amount greater than contract balance",
 
     "BA-LENM-01": "BannedAccounts: number of banned accounts and ban reasons do not match"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean-networkfiles": "rimraf .openzeppelin/unknown-*.json",
-    "hh-coverage": "npx hardhat coverage",
+    "hh-coverage": "yarn clean-networkfiles && npx hardhat clean && npx hardhat coverage",
     "hh-start-clean": "yarn clean-networkfiles && npx hardhat clean && npx hardhat node",
     "compile": "yarn hardhat compile",
     "size": "yarn hardhat size-contracts"

--- a/test/TestAuction.ts
+++ b/test/TestAuction.ts
@@ -439,7 +439,7 @@ it("Should not allow any order operation when mode = 5 (MATCHING)", async () => 
 
   const orderids: Array<string> = []
   orderids[0]= fOrder1.id;
-  await expect(cancelAllOrders(wallets[3], orderids, pair, orders)).to.be.revertedWith("T-PPAU-03");
+  await expect(cancelOrderList(wallets[3], orderids, pair, orders)).to.be.revertedWith("T-PPAU-03");
 });
 
 it("Should not allow anyone to withdraw auction token when mode = 5 (MATCHING)", async () => {
@@ -898,10 +898,10 @@ async function cancelOrder(wallet: SignerWithAddress, order: IOrder, pair: any, 
   return true;
 }
 
-async function cancelAllOrders(wallet: SignerWithAddress, orderIds: string[], pair: any, orders: Map<string, any>) {
+async function cancelOrderList(wallet: SignerWithAddress, orderIds: string[], pair: any, orders: Map<string, any>) {
   let orderLog: any = {};
 
-  const tx = await tradePairs.connect(wallet).cancelAllOrders(orderIds);
+  const tx = await tradePairs.connect(wallet).cancelOrderList(orderIds);
   orderLog = await tx.wait();
 
   if (orderLog){

--- a/test/TestAuctionPerfectMatch.ts
+++ b/test/TestAuctionPerfectMatch.ts
@@ -586,10 +586,10 @@ async function cancelOrder(wallet: SignerWithAddress, order: IOrder, pair: any, 
   return true;
 }
 
-async function cancelAllOrders(wallet: SignerWithAddress, orderIds: string[], pair: any, orders: Map<string, any>) {
+async function cancelOrderList(wallet: SignerWithAddress, orderIds: string[], pair: any, orders: Map<string, any>) {
   let orderLog: any = {};
 
-  const tx = await tradePairs.connect(wallet).cancelAllOrders(orderIds);
+  const tx = await tradePairs.connect(wallet).cancelOrderList(orderIds);
   orderLog = await tx.wait();
 
   if (orderLog){

--- a/test/TestPortfolioBridgeSub.ts
+++ b/test/TestPortfolioBridgeSub.ts
@@ -300,6 +300,27 @@ describe("Portfolio Bridge Sub", () => {
         expect(await portfolioBridgeSub.isBridgeProviderEnabled(1)).to.be.false;
     });
 
+    it("Should have gas Swap Amount 1 and bridgeFee 0 for AVAX in PortfolioBridgeSub", async () => {
+       // Avax is added with 0 gas in the subnet
+        let  params2 =await portfolioSub.bridgeParams(AVAX);
+        expect(params2.gasSwapRatio).to.equal(Utils.toWei("0"));
+        expect(params2.fee).to.equal(0);
+        expect(params2.usedForGasSwap).to.equal(false);
+
+        // Fail for non-bridge admin
+        await expect ( portfolioBridgeSub.setBridgeParam(AVAX, Utils.toWei("0.3"), Utils.toWei("0"), true)).to.revertedWith("AccessControl:")
+        // give BRIDGE_ADMIN to owner
+        await portfolioBridgeSub.grantRole(portfolioBridgeSub.BRIDGE_ADMIN_ROLE(), owner.address);
+        await expect (portfolioBridgeSub.setBridgeParam(AVAX, Utils.toWei("0.3"), Utils.toWei("0"), true)).to.revertedWith("P-GSRO-01")
+        await portfolioBridgeSub.setBridgeParam(AVAX,  Utils.toWei("0.2"), Utils.toWei("0.1"), true)
+        params2 =await portfolioSub.bridgeParams(AVAX);
+        expect(params2.gasSwapRatio).to.equal(Utils.toWei("0.1"));
+        expect(params2.fee).to.equal(Utils.toWei("0.2"));
+        expect(params2.usedForGasSwap).to.equal(true); // always false in the mainnet
+
+    });
+
+
     it("Should revoke role", async () => {
         const {owner, admin} = await f.getAccounts();
         await expect(portfolioBridgeSub.revokeRole(await portfolioBridgeSub.DEFAULT_ADMIN_ROLE(), owner.address)).to.be.revertedWith("PB-ALOA-01");

--- a/test/TestPortfolioShared.ts
+++ b/test/TestPortfolioShared.ts
@@ -258,7 +258,7 @@ describe("Portfolio Shared", () => {
     it("Should set and get bridgeFee", async () => {
         // fail for non-admin
         await expect(portfolio.connect(trader1).setBridgeParam(AVAX, bridgeFee, 0, true))
-        .to.be.revertedWith("AccessControl: account");
+        .to.be.revertedWith("P-OACC-01");
 
         // 0 gasSwapRatio Fail
         await expect(portfolio.setBridgeParam(AVAX, Utils.toWei("0.1"), 0, true)).to.revertedWith("P-GSRO-01");
@@ -275,8 +275,8 @@ describe("Portfolio Shared", () => {
         const USDT = Utils.fromUtf8("USDT")
 
         // fail from non admin accounts
-        await expect(portfolio.connect(trader1).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true)).to.revertedWith("AccessControl: account");
-        await expect(portfolioSub.connect(admin).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true)).to.revertedWith("AccessControl: account");
+        await expect(portfolio.connect(trader1).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true)).to.revertedWith("P-OACC-01");
+        await expect(portfolioSub.connect(admin).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true)).to.revertedWith("P-OACC-01");
         // succeed from admin accounts
         await portfolio.grantRole(portfolio.DEFAULT_ADMIN_ROLE(), admin.address);
         await expect (portfolio.connect(admin).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true))
@@ -301,8 +301,8 @@ describe("Portfolio Shared", () => {
         const USDT = Utils.fromUtf8("USDT")
 
         // fail from non admin accounts
-        await expect(portfolio.connect(trader1).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true)).to.revertedWith("AccessControl: account");
-        await expect(portfolioSub.connect(admin).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true)).to.revertedWith("AccessControl: account");
+        await expect(portfolio.connect(trader1).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true)).to.revertedWith("P-OACC-01");
+        await expect(portfolioSub.connect(admin).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true)).to.revertedWith("P-OACC-01");
         // succeed from admin accounts
         await portfolio.grantRole(portfolio.DEFAULT_ADMIN_ROLE(), admin.address);
         await expect (portfolio.connect(admin).setBridgeParam(USDT, 0, Utils.toWei("0.1"), true))

--- a/test/TestPortfolioSub.ts
+++ b/test/TestPortfolioSub.ts
@@ -320,15 +320,15 @@ describe("Portfolio Sub", () => {
         const gasPrice = await ethers.provider.getGasPrice()
         const total = gas.mul(gasPrice)
         const gasThreshold = (await gasStation.gasAmount()).mul(2);
-//        console.log (Utils.formatUnits(initial_amount,18), "gasth", Utils.formatUnits(gasThreshold,18))
 
         // Fail when more than available is being deposited into the portfolio
-        // For some reason , revertWith is not matching the error , cd Jan30,23
-        // await expect(portfolio.connect(trader1).depositNative(trader1.address, 0, {
-        //     value: initial_amount.mul(2),
-        //     gasLimit: gas,
-        //     gasPrice: gasPrice
-        // })).to.be.revertedWith("InvalidInputError: sender doesn't have enough funds to send tx. The max upfront cost is: 2000000000169000320237961 and the sender's account only has: 1000000000000000000000000");
+        // For some reason, revertWith is not matching the error, cd Jan30,23
+        // Catching for now with a catch-all "await expect(...).to throw"
+        await expect(portfolio.connect(trader1).depositNative(trader1.address, 0, {
+            value: initial_amount.mul(2),
+            gasLimit: gas,
+            gasPrice: gasPrice
+        })).to.throw;
 
         //Fail when trying to leave almost 0 in the wallet
         await expect(portfolio.connect(trader1).depositNative(trader1.address, 0, {


### PR DESCRIPTION
TradePairs: (Functionality for addLimitOrderList can emit OrderStatusChanged with status= REJECTED instead of reverting)
- Removed the last function paramater "_revertOnPO" from addLimitOrderList
- Added a new field to the end of OrderStatusChanged event called "code"
- Incremented ORDER_STATUS_CHANGED_VERSION field in OrderStatusChanged event to 2 from 1
- Used Previously unused REJECTED from enum "Status" so addLimitOrderList can emit OrderStatusChanged with status= REJECTED instead of reverting.
- Added CANCEL_REJECT at the end of enum "Status" so cancelOrderList can emit OrderStatusChanged with status= CANCEL_REJECT if order already closed
- Renamed cancelAllOrders to cancelOrderList as only the supplied list is canceled, not all open orders
- portoflioSub.AutoFill is also being called at the end of addOrder function
- removed redundant cast
- gas optimization (++i) where possible

PortfolioSub:
- DepositNative(RemoveGas) Bug Fix where you can only deposit half of ALOT wallet balances at a time when in subnet.
- Expose transferToken & getBalance via Interface so it can be called by IncentiveDistributor
- Granted access to setBridgeParams function for PORTFOLIO_BRIDGE_ROLE
- gas optimization (++i) where possible

PortfolioBridge:
- added setBridgeParams function that needs BRIDGE_ADMIN_ROLE that calles portfolio.setBridgeParams
- gas optimization (++i) where possible

IncentiveDistributor
- Enhanced it to be deployed in the subnet and use the portfolioSub.transferToken function to distribute the rewards rather than using ERC20 tokens in the mainnet.
(Much more gas effective in the subnet)


PortfolioMain, OrderBooks, PortfolioBridgeSub, UtilsLibrary:
- gas optimization (++i) where possible