### PR TITLE
Remediation 0324

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,38 +50,42 @@ npx hardhat test test/TestAirdrop.ts
 Available tests are as follows:
 
 ```sh
-TestAirdrop.ts
-TestAuction.ts
-TestAuctionPerfectMatch.ts
-TestBannedAccounts.ts
-TestBytes32LinkedListLibrary.ts
-TestDexalot.ts
-TestDexalotToken.ts
-TestExchangeMain.ts
-TestExchangeShared.ts
-TestExchangeSub.ts
-TestGasStation.ts
-TestGetNBook.ts
-TestIncentiveDistributor.ts
-TestLzApp.ts
-TestLzDestroyAndRecoverFunds.ts
-TestMockToken.ts
-TestMulticall2.ts
-TestMainnetRFQ.ts
-TestOrderBooks.ts
-TestPortfolioBridgeMain.ts
-TestPortfolioBridgeSub.ts
-TestPortfolioInteractions.ts
-TestPortfolioMain.ts
-TestPortfolioMinter.ts
-TestPortfolioShared.ts
-TestPortfolioSub.ts
-TestRBTLibrary.ts
-TestStaking.ts
-TestTokenVestingCloneable.ts
-TestTokenVestingCloneFactory.ts
-TestTradePairs.ts
-TestUtilsLibrary.ts
+npx hardhat  test ./test/TestAirdrop.ts
+npx hardhat  test ./test/TestAuction.ts
+npx hardhat  test ./test/TestAuctionPerfectMatch.ts
+npx hardhat  test ./test/TestBannedAccounts.ts
+npx hardhat  test ./test/TestBytes32LinkedListLibrary.ts
+npx hardhat  test ./test/TestDexalot.ts
+npx hardhat  test ./test/TestDexalotToken.ts
+npx hardhat  test ./test/TestExchangeMain.ts
+npx hardhat  test ./test/TestExchangeShared.ts
+npx hardhat  test ./test/TestExchangeSub.ts
+npx hardhat  test ./test/TestGasStation.ts
+npx hardhat  test ./test/TestGetNBook.ts
+npx hardhat  test ./test/TestIncentiveDistributor.ts
+npx hardhat  test ./test/TestLzApp.ts
+npx hardhat  test ./test/TestLzDestroyAndRecoverFunds.ts
+npx hardhat  test ./test/TestMockToken.ts
+npx hardhat  test ./test/TestMulticall2.ts
+npx hardhat  test ./test/TestMainnetRFQ.ts
+npx hardhat  test ./test/TestOrderBooks.ts
+npx hardhat  test ./test/TestPortfolioBridgeMain.ts
+npx hardhat  test ./test/TestPortfolioBridgeSub.ts
+npx hardhat  test ./test/TestPortfolioInteractions.ts
+npx hardhat  test ./test/TestPortfolioMain.ts
+npx hardhat  test ./test/TestPortfolioMinter.ts
+npx hardhat  test ./test/TestPortfolioShared.ts
+npx hardhat  test ./test/TestPortfolioSub.ts
+npx hardhat  test ./test/TestRBTLibrary.ts
+npx hardhat  test ./test/TestTokenVestingCloneable.ts
+npx hardhat  test ./test/TestTokenVestingCloneFactory.ts
+npx hardhat  test ./test/TestTradePairs.ts
+npx hardhat  test ./test/TestUtilsLibrary.ts
+npx hardhat  test ./test/TestInventoryManager.ts
+npx hardhat  test ./test/TestMainnetRFQ.ts
+npx hardhat  test ./test/TestMultiChain.ts
+npx hardhat  test ./test/TestPBMainToPBMain.ts
+npx hardhat  test ./test/TestPortfolioSubHelper.ts
 ```
 
 The scripts `TestDexalot.ts`, `TestAuction.ts` and `TestGetNBook.ts` run a set of simulated trades to test the whole system.  Before running any simulator a second time you need to stop a running ```yarn hh-start-clean``` script and rerun ```yarn hh-start-clean``` to reset all the counters.

--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -246,8 +246,8 @@ abstract contract Portfolio is
         bytes32 symbolId = UtilsLibrary.getIdForToken(_details.symbol, tokenDetails.srcChainId);
         tokenDetails.symbolId = symbolId;
         tokenDetails.isVirtual = _details.isVirtual;
-        //sourceChainSymbol is always equal to symbol for Portfolios.abi
-        //It is needed and can be different in PortfolioBrigeSub
+        //sourceChainSymbol is always equal to symbol for Portfolios
+        //It is needed specifically in PortfolioBridgeSub and can be different
         tokenDetails.sourceChainSymbol = _details.symbol;
         //add to the list by symbol
         tokenList.add(_details.symbol);

--- a/contracts/PortfolioBridgeMain.sol
+++ b/contracts/PortfolioBridgeMain.sol
@@ -37,7 +37,7 @@ import "./bridgeApps/LzApp.sol";
  *
  * In addition, to be able to support cross chain trades for subnets like Gunzilla that only has their gas token
  * and no ERC20 available, we introduced a new flow where you provide the counter token in an L1 and receive your GUN
- * in Gunzilla network. Similarly you can sell your GUN in Gunzilla network and receive your counter token in the L1.
+ * in Gunzilla network. Similarly you can sell your GUN in Gunzilla network and receive your counter token in any L1.
  * MainnetRFQ(Avax) => PortfolioBridgeMain(Avax) => BridgeProviderA/B/n => PortfolioBridgeMain(Gun) => MainnetRFQ(Gun) \
  * Buy GUN from Avalanche with counter token USDC. USDC is kept in MainnetRFQ(Avax) and GUN is deposited to the buyer's
  * wallet via MainnetRFQ(Gun)
@@ -45,9 +45,8 @@ import "./bridgeApps/LzApp.sol";
  * Sell GUN from Gunzilla with counter token USDC. GUN is kept in MainnetRFQ(Gun) and USDC is deposited to the buyer's
  * wallet via MainnetRFQ(Avax)
  * The same flow can be replicated with any other L1 like Arb as well. \
- * PortfolioBridgeMain always sends the ERC20 Symbol and expects the same back,
- * i.e USDt in Avalanche Mainnet.
-
+ * PortfolioBridgeMain always sends the ERC20 Symbol from its own network and expects the same back
+ * i.e USDt sent & received in Avalanche Mainnet whereas USDT is sent & received in Arbitrum.
  * Use multiple inheritance to add additional bridge implementations in the future. Currently LzApp only.
  */
 
@@ -379,32 +378,42 @@ contract PortfolioBridgeMain is
     }
 
     /**
-     * @notice  Returns the symbol given the destination chainId
-     * @dev    Returns itself in the mainnet but
-     * Overridden in PortfolioBridgeSub to return the destination chains local symbol
-     * param   _dstChainListOrgChainId  destination chain id
+     * @notice  Returns the symbol & symbolId given the destination chainId
+     * @dev    Returns ERC20 Symbol in the host chain for both symbol & symbolId as long
+     * as the token has been added to the Portfolio
+     * Overridden in PortfolioBridgeSub
      * @param   _symbol  symbol of the token
-     * @return  bytes32  destination symbol
+     * @return  dstSymbol  destination symbol
+     * @return  dstSymbolId  symbolId of the target chain
      */
 
-    function getDestChainSymbol(uint32, bytes32 _symbol) internal view virtual returns (bytes32) {
-        return _symbol;
+    function getDestChainSymbol(
+        uint32,
+        bytes32 _symbol
+    ) internal view virtual returns (bytes32 dstSymbol, bytes32 dstSymbolId) {
+        IPortfolio.TokenDetails memory details = portfolio.getTokenDetails(_symbol); //returns _symbol
+        dstSymbol = details.symbol; // dest Symbol is equal to _symbol
+        dstSymbolId = dstSymbol; // dest SymbolId is equal to _symbol for host chains
+        require(dstSymbol != bytes32(0), "PB-ETNS-01");
     }
 
     /**
-     * @notice  Returns the locally used symbol, symbolId given the chainListOrgChainId
-     * @dev     Mainnet receives the messages in the same format that it sent out, by its ERC20 Symbol
-     * Returns itself in the mainnet but overridden in PortfolioBridgeSub
-     * param   _chainListOrgChainId src/dest chain id only relevant in the overriding function PortfolioBridgeSub
+     * @notice  Returns the locally used symbol, and source symbolId given the chainListOrgChainId
+     * @dev     Returns ERC20 Symbol in the host chain for both symbol & symbolId as long
+     * as the token has been added to the Portfolio
+     * Host chain expect to receive the symbol in the same format that it sent out.(ERC20 Symbol)
+     * Overridden in PortfolioBridgeSub
      * @return  localSymbol
      * @return  symbolId
      */
-    function getSymbolForId(
+    function getMappedSymbols(
         uint32,
         bytes32 _symbol
     ) internal view virtual returns (bytes32 localSymbol, bytes32 symbolId) {
-        localSymbol = _symbol;
-        symbolId = _symbol;
+        IPortfolio.TokenDetails memory details = portfolio.getTokenDetails(_symbol); //returns _symbol
+        localSymbol = details.symbol; // Local Symbol is equal to _symbol
+        symbolId = localSymbol; // symbolId is equal to _symbol for host chains
+        require(localSymbol != bytes32(0), "PB-ETNS-01");
     }
 
     /**
@@ -458,17 +467,12 @@ contract PortfolioBridgeMain is
     }
 
     /**
-     * @notice  Unpacks XChainMsgType & XFER message from the payload and returns the local symbol using symbolId
+     * @notice  Unpacks XChainMsgType & XFER message from the payload and returns the local symbol and symbolId
      * @dev     Currently only XChainMsgType.XFER possible. For more details on payload packing see packXferMessage
-     * @param   _srcChainListOrgChainId the source chain id
      * @param   _payload  Payload passed from the bridge
      * @return  xfer IPortfolio.XFER  Xfer Message
-     * @return  localSymbol  Local Symbol of the token
      */
-    function unpackXFerMessage(
-        uint32 _srcChainListOrgChainId,
-        bytes calldata _payload
-    ) external view returns (IPortfolio.XFER memory xfer, bytes32 localSymbol) {
+    function unpackXFerMessage(bytes calldata _payload) external pure returns (IPortfolio.XFER memory xfer) {
         // There is only a single type in the XChainMsgType enum.
         bytes32[4] memory msgData = abi.decode(_payload, (bytes32[4]));
         uint256 slot0 = uint256(msgData[0]);
@@ -479,11 +483,10 @@ contract PortfolioBridgeMain is
         slot0 >>= 16;
         xfer.nonce = uint64(slot0);
         xfer.trader = address(uint160(slot0 >> 64));
+        xfer.symbol = msgData[1];
         xfer.quantity = uint256(msgData[2]);
         xfer.timestamp = uint32(bytes4(msgData[3]));
         xfer.customdata = bytes28(uint224(uint256(msgData[3]) >> 32));
-
-        (localSymbol, xfer.symbol) = getSymbolForId(_srcChainListOrgChainId, msgData[1]);
     }
 
     /**
@@ -493,18 +496,10 @@ contract PortfolioBridgeMain is
      * slot1: symbol(32)
      * slot2: quantity(32)
      * slot3: customdata(28), timestamp(4)
-     * @param   _dstChainListOrgChainId the destination chain identifier
      * @param   _xfer  XFER message to encode
      * @return  message  Encoded XFER message
-     * @return  localSymbol  Local Symbol used. ERC20 in the mainnet
      */
-    function packXferMessage(
-        uint32 _dstChainListOrgChainId,
-        IPortfolio.XFER memory _xfer
-    ) internal view returns (bytes memory message, bytes32 localSymbol) {
-        localSymbol = _xfer.symbol;
-        //overwrite with the destination Chain's symbol
-        _xfer.symbol = getDestChainSymbol(_dstChainListOrgChainId, _xfer.symbol);
+    function packXferMessage(IPortfolio.XFER memory _xfer) private pure returns (bytes memory message) {
         bytes32 slot0 = bytes32(
             (uint256(uint160(_xfer.trader)) << 96) |
                 (uint256(_xfer.nonce) << 32) |
@@ -554,15 +549,12 @@ contract PortfolioBridgeMain is
         if (_xfer.nonce == 0) {
             _xfer.nonce = incrementOutNonce(_bridge, dstChainId);
         }
+        bytes32 localSymbol = _xfer.symbol;
+        bytes32 destSymbolId;
         //_xfer.symbol is overridden with the symbol the destination expects in the below method
-        (bytes memory _payload, bytes32 localSymbol) = packXferMessage(_dstChainListOrgChainId, _xfer);
+        (_xfer.symbol, destSymbolId) = getDestChainSymbol(_dstChainListOrgChainId, _xfer.symbol);
 
-        // If this is a cross chain transfer, it doesn't affect the inventory
-        if (_xfer.transaction != IPortfolio.Tx.CCTRADE) {
-            (, bytes32 dstSymbolId) = getSymbolForId(_dstChainListOrgChainId, _xfer.symbol);
-            updateInventoryBySource(localSymbol, dstSymbolId, _xfer.quantity, _xfer.transaction);
-        }
-
+        bytes memory _payload = packXferMessage(_xfer);
         if (_bridge == BridgeProvider.LZ) {
             uint256 messageFee = _lzSend(dstChainId, _payload, _userFeePayer);
             emit XChainXFerMessage(
@@ -576,6 +568,12 @@ contract PortfolioBridgeMain is
         } else {
             // Just in case a bridge other than LZ is enabled accidentally
             revert("PB-RBNE-02");
+        }
+        // If this is NOT a cross chain transfer, update the inventory
+        if (_xfer.transaction != IPortfolio.Tx.CCTRADE) {
+            // overrite the symbol with symbolId for proper inventory calculations
+            _xfer.symbol = destSymbolId;
+            updateInventoryBySource(localSymbol, _xfer);
         }
     }
 
@@ -624,7 +622,8 @@ contract PortfolioBridgeMain is
      * @param   _payload  Payload received
      */
     function processPayload(BridgeProvider _bridge, uint32 _srcChainListOrgChainId, bytes calldata _payload) private {
-        (IPortfolio.XFER memory xfer, bytes32 localSymbol) = this.unpackXFerMessage(_srcChainListOrgChainId, _payload);
+        IPortfolio.XFER memory xfer = this.unpackXFerMessage(_payload);
+
         xfer.timestamp = block.timestamp; // log receival/process timestamp
         emit XChainXFerMessage(
             XCHAIN_XFER_MESSAGE_VERSION,
@@ -634,15 +633,17 @@ contract PortfolioBridgeMain is
             0,
             xfer
         );
-
-        // If this is a cross chain transfer, it doesn't affect the inventory
+        bytes32 localSymbol;
+        // check the validity of the symbol(mainnet) or overwrite the xfer.symbol with the
+        // sourceSymbol + chainId (in the subnet)
+        (localSymbol, xfer.symbol) = getMappedSymbols(_srcChainListOrgChainId, xfer.symbol);
         if (xfer.transaction == IPortfolio.Tx.CCTRADE) {
             mainnetRfq.processXFerPayload(xfer);
         } else {
             // Update the totals by symbolId for multichain inventory management.
             // Add xfer.quantity to the totals by SymbolId. It will be used to see how much the user
             // can withdraw from the target chain.
-            updateInventoryBySource(localSymbol, xfer.symbol, xfer.quantity, xfer.transaction);
+            updateInventoryBySource(localSymbol, xfer);
             //After the inventory is updated, process the XFer with the local symbol that Portfolio needs
             portfolio.processXFerPayload(xfer.trader, localSymbol, xfer.quantity, xfer.transaction);
         }
@@ -682,12 +683,7 @@ contract PortfolioBridgeMain is
      * @dev     Update the inventory by each chain only in the Subnet.
      * Inventory in the host chains are already known and don't need to be calculated
      */
-    function updateInventoryBySource(
-        bytes32 _localSymbol,
-        bytes32 _sourceSymbolId,
-        uint256 _quantity,
-        IPortfolio.Tx _transaction
-    ) internal virtual {}
+    function updateInventoryBySource(bytes32 _localSymbol, IPortfolio.XFER memory _xfer) internal virtual {}
 
     /**
      * @notice  private function that handles the addition of native token

--- a/contracts/PortfolioBridgeSub.sol
+++ b/contracts/PortfolioBridgeSub.sol
@@ -16,17 +16,18 @@ import "./interfaces/IInventoryManager.sol";
  * As a result the PortfolioSub tokenDetails are quite different than the PortfolioBridgeSub tokenDetails.
  * PortfolioBridgeSub always maps the symbol that it receives into a subnet symbol and also attaches the source
  * chainId to the source Symbol to construct a symbolId to facilitate inventory management on receipt.
- * PortfolioSub expects the subnet symbol. i.e USDt is mapped to USDT43113 & USDT as symbolId and subnet symbol
+ * PortfolioSub expects the subnet symbol. i.e USDt is mapped to (USDT43113, USDT) as symbolId and subnet symbol
  * respectively. Similarly USDTx from another chain can also be mapped to USDC. This way liquidity can
  * be combined and traded together in a multichain implementation.
  * Similarly it keeps track of the token positions from each chain independently and it will have a different bridge
  * fee depending on the available inventory at the target chain (where the token will be withdrawn).
  * When sending back to the target chain, it maps the subnet symbol back to the expected symbol by the target chain,
- * i.e ETH to ETH if sent back to Ethereum, WETH.e if sent to Avalanche. \
- * Symbol mapping happens in packXferMessage on the way out. packXferMessage calls getDestChainSymbol.
- * On the receival, the symbol mapping will happen in unpackXFerMessage. getSymbolForId is called
+ * i.e ETH to ETH if sent back to Ethereum, ETH to WETH.e if sent to Avalanche. \
+ * Symbol mapping happens in sendXChainMessageInternal on the way out. sendXChainMessageInternal uses getDestChainSymbol.
+ * On the receival, the symbol mapping will happen in processPayload. getMappedSymbols is used
  * where xfer.symbol is overriden with symbolId (sourceSymbol + sourceChainId) and also the subnet symbol is returned. \
- * The XChainXFerMessage always contain the source Symbol & source Chain id on the way in and out.
+ * The XChainXFerMessage always contains the host chain's ERC20 Symbol in xfer.symbol & source Chain id in
+ * remoteChainId on the way in and out.
  */
 
 // The code in this file is part of Dexalot project.
@@ -84,8 +85,9 @@ contract PortfolioBridgeSub is PortfolioBridgeMain, IPortfolioBridgeSub {
      * @param   _tokenAddress  Mainnet token address the symbol or zero address for AVAX
      * @param   _srcChainId  Source Chain id
      * @param   _decimals  Decimals of the token
+     * param   ITradePairs.AuctionMode  irrelevant for PBridge
      * @param   _subnetSymbol  Subnet Symbol of the token (Shared Symbol of the same token from different chains)
-
+     * @param   _bridgeFee  Bridge Fee
      */
     function addToken(
         bytes32 _srcChainSymbol,
@@ -133,7 +135,6 @@ contract PortfolioBridgeSub is PortfolioBridgeMain, IPortfolioBridgeSub {
      * @param   _srcChainSymbol  Source Chain Symbol of the token
      * @param   _srcChainId  Source Chain id
      * @param   _subnetSymbol  symbol of the token
-
      */
     function removeToken(
         bytes32 _srcChainSymbol,
@@ -167,18 +168,24 @@ contract PortfolioBridgeSub is PortfolioBridgeMain, IPortfolioBridgeSub {
     }
 
     /**
-     * @notice  Returns the symbolId of the targetChainId
+     * @notice  Returns the target symbol & symbolId given the destination chainId
      * @dev     PortfolioBridgeSub uses its internal token list & the defaultTargetChain to resolve the mapping
-     * When sending from Mainnet to Subnet we send out the symbolId of the sourceChain. USDC => USDC43114
-     * Because the subnet needs to know about different ids from different mainnets.
-     * When sending messages Subnet to Mainnet, it resolves it back to the symbolId the target chain expects
-     * @param   _dstChainListOrgChainId  destination chain id
-     * @param   _symbol  symbol of the token
-     * @return  bytes32  symbolId for the destination
+     * When sending from Mainnet to Subnet we send out the symbol of the sourceChain. BTC.b => BTC.b
+     * When sending messages back to mainnet we use this function to resolve the symbol.
+     * BTC could be resolved to BTC.b for avalanche and WBTC for Arbitrum
+     * @param   _dstChainListOrgChainId destination chain id
+     * @param   _subnetSymbol  subnet symbol of the token
+     * @return  dstSymbol  symbol of the target chain
+     * @return  dstSymbolId  symbolId of the target chain
      */
 
-    function getTokenId(uint32 _dstChainListOrgChainId, bytes32 _symbol) internal view returns (bytes32) {
-        return tokenInfoMapBySymbolChainId[_symbol][_dstChainListOrgChainId].symbolId;
+    function getDestChainSymbol(
+        uint32 _dstChainListOrgChainId,
+        bytes32 _subnetSymbol
+    ) internal view override returns (bytes32 dstSymbol, bytes32 dstSymbolId) {
+        dstSymbolId = tokenInfoMapBySymbolChainId[_subnetSymbol][_dstChainListOrgChainId].symbolId;
+        dstSymbol = tokenDetailsMapById[dstSymbolId].sourceChainSymbol;
+        require(dstSymbol != bytes32(0), "PB-ETNS-01");
     }
 
     /**
@@ -230,42 +237,24 @@ contract PortfolioBridgeSub is PortfolioBridgeMain, IPortfolioBridgeSub {
     }
 
     /**
-     * @notice  Returns the locally used symbol, symbolId given the chainListOrgChainId
+     * @notice  Returns the locally used symbol, symbolId given the chainListOrgChainId & source chain symbol
      * @dev     Mainnet receives the messages in the same format that it sent out, by its ERC20 symbol
      * Subnet has its own standardized list of symbols i.e. BTC.b in the mainnet may be mapped to BTC
-     * in the subnet
+     * in the subnet. \
      * The subnet knows which chain the message is coming from and will tag the chainId to the sourceSymbol
-     * for certain inventory operations before mapping it to and uses this function.
-     * It needs to keep track of the inventory coming from different mainnets.
+     * to keep track of the inventory coming from different mainnets.
      * @param   _chainListOrgChainId source/Destination chain id
+     * @param   _symbol source symbol
      * @return  localSymbol (subnetSymbol)
      * @return  symbolId symbolId of the source/destination Chain, symbol + chainId
      */
-    function getSymbolForId(
+    function getMappedSymbols(
         uint32 _chainListOrgChainId,
         bytes32 _symbol
     ) internal view override returns (bytes32 localSymbol, bytes32 symbolId) {
         symbolId = UtilsLibrary.getIdForToken(_symbol, _chainListOrgChainId);
         localSymbol = tokenDetailsMapById[symbolId].symbol;
         require(localSymbol != bytes32(0), "PB-ETNS-01");
-    }
-
-    /**
-     * @notice  Returns the symbol given the destination chainId
-     * @dev     When sending from Mainnet to Subnet we send out the symbol of the sourceChain. BTC.b => BTC.b
-     * When sending messages back to mainnet we use this function to resolve the symbol.
-     * BTC could be resolved to BTC.b for avalanche and WBTC for Arbitrum
-     * @param   _dstChainListOrgChainId destination chain id
-     * @param   _subnetSymbol  subet symbol of the token
-     * @return  bytes32  symbol of the target chain
-     */
-
-    function getDestChainSymbol(
-        uint32 _dstChainListOrgChainId,
-        bytes32 _subnetSymbol
-    ) internal view override returns (bytes32) {
-        bytes32 symbolId = getTokenId(_dstChainListOrgChainId, _subnetSymbol);
-        return tokenDetailsMapById[symbolId].sourceChainSymbol;
     }
 
     /**
@@ -321,16 +310,11 @@ contract PortfolioBridgeSub is PortfolioBridgeMain, IPortfolioBridgeSub {
      * Inventory available per host chain. i.e. USDC may exist in both Avalanche and Arbitrum
      */
 
-    function updateInventoryBySource(
-        bytes32 _localSymbol,
-        bytes32 _sourceSymbolId,
-        uint256 _quantity,
-        IPortfolio.Tx _transaction
-    ) internal override {
-        if (_transaction == IPortfolio.Tx.WITHDRAW) {
-            inventoryManager.decrement(_localSymbol, _sourceSymbolId, _quantity);
-        } else if (_transaction == IPortfolio.Tx.DEPOSIT) {
-            inventoryManager.increment(_localSymbol, _sourceSymbolId, _quantity);
+    function updateInventoryBySource(bytes32 _localSymbol, IPortfolio.XFER memory _xfer) internal override {
+        if (_xfer.transaction == IPortfolio.Tx.WITHDRAW) {
+            inventoryManager.decrement(_localSymbol, _xfer.symbol, _xfer.quantity);
+        } else if (_xfer.transaction == IPortfolio.Tx.DEPOSIT) {
+            inventoryManager.increment(_localSymbol, _xfer.symbol, _xfer.quantity);
         }
     }
 
@@ -351,7 +335,7 @@ contract PortfolioBridgeSub is PortfolioBridgeMain, IPortfolioBridgeSub {
         bytes32 _toSymbol
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_fromSymbol != _toSymbol, "PB-LENM-01");
-        bytes32 fromSymbolId = getTokenId(_dstChainListOrgChainId, _fromSymbol);
+        (, bytes32 fromSymbolId) = getDestChainSymbol(_dstChainListOrgChainId, _fromSymbol);
         IPortfolio.TokenDetails storage tokenDetails = tokenDetailsMapById[fromSymbolId];
         tokenDetails.symbol = _toSymbol;
         tokenInfoMapBySymbolChainId[_toSymbol][_dstChainListOrgChainId] = tokenInfoMapBySymbolChainId[_fromSymbol][
@@ -408,7 +392,7 @@ contract PortfolioBridgeSub is PortfolioBridgeMain, IPortfolioBridgeSub {
         if (_bridge == BridgeProvider.LZ) {
             bridgeFee = tokenInfoMapBySymbolChainId[_symbol][_dstChainListOrgChainId].bridgeFee;
         }
-        bytes32 symbolId = getTokenId(_dstChainListOrgChainId, _symbol);
+        (, bytes32 symbolId) = getDestChainSymbol(_dstChainListOrgChainId, _symbol);
         bridgeFee += inventoryManager.calculateWithdrawalFee(_symbol, symbolId, _quantity);
     }
 }

--- a/contracts/PortfolioMain.sol
+++ b/contracts/PortfolioMain.sol
@@ -93,10 +93,10 @@ contract PortfolioMain is Portfolio, IPortfolioMain {
                 _decimals,
                 _tokenAddress,
                 ITradePairs.AuctionMode.OFF, // Auction Mode is ignored as it is irrelevant in the Mainnet
-                _isVirtual ? _srcChainId : chainId, // always add with the chain id of the Portfolio unless virtual
-                _symbol,
-                bytes32(0),
-                _symbol,
+                _isVirtual ? _srcChainId : chainId, // srcChainId. always add with the chain id of the Portfolio unless virtual
+                _symbol, //symbol
+                bytes32(0), //symbolId
+                _symbol, //sourceChainSymbol, it is always equal to symbol for PortfolioMain
                 _isVirtual
             );
 

--- a/contracts/PortfolioSub.sol
+++ b/contracts/PortfolioSub.sol
@@ -541,20 +541,19 @@ contract PortfolioSub is Portfolio, IPortfolioSub {
         require(tokenDetailsMap[_symbol].auctionMode == ITradePairs.AuctionMode.OFF, "P-AUCT-01");
         require(_to == msg.sender || msg.sender == address(this), "P-OOWT-01");
         require(tokenList.contains(_symbol), "P-ETNS-02");
-
-        // bridgeFee = bridge Fees both in the Mainnet the subnet
-        // no bridgeFees for treasury and feeCollector
-        // bridgeParams[_symbol].fee is redundant as of Feb 10, 2024 CD
-        uint256 bridgeFee = portfolioSubHelper.isAdminAccountForRates(_to)
-            ? 0
-            : portfolioBridge.getBridgeFee(_bridge, _dstChainListOrgChainId, _symbol, _quantity);
-        safeDecrease(_to, _symbol, _quantity, bridgeFee, Tx.WITHDRAW, _to);
-        //if the token is in the conversion list, overwrite it with the new symbol before withdrawal
+        //if the token is in the conversion list, we need to use it in the withdrawal
         //message for proper inventory management
         bytes32 toSymbol = portfolioSubHelper.getSymbolToConvert(_symbol);
-        if (toSymbol != bytes32(0)) {
-            _symbol = toSymbol;
-        }
+        toSymbol == bytes32(0) ? toSymbol = _symbol : toSymbol;
+        // bridgeFee = bridge Fees both in the Mainnet the subnet
+        // no bridgeFees for treasury and feeCollector (isAdminAccountForRates)
+        // bridgeParams[_symbol].fee is redundant as of Feb 10, 2024 CD
+        // We need to get the bridgeFee with the new(after conversion) toSymbol
+        uint256 bridgeFee = portfolioSubHelper.isAdminAccountForRates(_to)
+            ? 0
+            : portfolioBridge.getBridgeFee(_bridge, _dstChainListOrgChainId, toSymbol, _quantity);
+        // We need to safeDecrease with the original(non-converted _symbol)
+        safeDecrease(_to, _symbol, _quantity, bridgeFee, Tx.WITHDRAW, _to);
         portfolioBridge.sendXChainMessage(
             _dstChainListOrgChainId,
             _bridge,
@@ -562,7 +561,7 @@ contract PortfolioSub is Portfolio, IPortfolioSub {
                 0, // Nonce to be assigned in PBridge
                 Tx.WITHDRAW,
                 _to,
-                _symbol,
+                toSymbol,
                 // Send the Net amount to Mainnet
                 _quantity - bridgeFee,
                 block.timestamp,

--- a/contracts/interfaces/IMainnetRFQ.sol
+++ b/contracts/interfaces/IMainnetRFQ.sol
@@ -12,13 +12,7 @@ import "./IPortfolio.sol";
 // Copyright 2022 Dexalot.
 
 interface IMainnetRFQ {
-    function processXFerPayload(
-        address _trader,
-        bytes32 _symbol,
-        uint256 _quantity,
-        IPortfolio.Tx _transaction,
-        bytes28 _customdata
-    ) external;
+    function processXFerPayload(IPortfolio.XFER calldata _xfer) external;
 
     function pause() external;
 

--- a/contracts/interfaces/IPortfolioBridge.sol
+++ b/contracts/interfaces/IPortfolioBridge.sol
@@ -26,10 +26,7 @@ interface IPortfolioBridge {
         address _userFeePayer
     ) external payable;
 
-    function unpackXFerMessage(
-        uint32 _srcChainListOrgChainId,
-        bytes calldata _data
-    ) external view returns (IPortfolio.XFER memory xfer, bytes32 localSymbol);
+    function unpackXFerMessage(bytes calldata _data) external view returns (IPortfolio.XFER memory xfer);
 
     function enableBridgeProvider(BridgeProvider _bridge, bool _enable) external;
 

--- a/contracts/interfaces/IPortfolioBridge.sol
+++ b/contracts/interfaces/IPortfolioBridge.sol
@@ -24,9 +24,12 @@ interface IPortfolioBridge {
         BridgeProvider _bridge,
         IPortfolio.XFER memory _xfer,
         address _userFeePayer
-    ) external payable returns (uint256 messageFee);
+    ) external payable;
 
-    function getXFerMessage(bytes calldata _data) external view returns (IPortfolio.XFER memory, bytes32);
+    function unpackXFerMessage(
+        uint32 _srcChainListOrgChainId,
+        bytes calldata _data
+    ) external view returns (IPortfolio.XFER memory xfer, bytes32 localSymbol);
 
     function enableBridgeProvider(BridgeProvider _bridge, bool _enable) external;
 

--- a/contracts/mocks/MainnetRFQAttacker.sol
+++ b/contracts/mocks/MainnetRFQAttacker.sol
@@ -59,7 +59,8 @@ contract MainnetRFQAttacker {
     ) external payable {
         functionToAttack = Function.PROCESS_XFER_PAYLOAD;
         params = abi.encode(_trader, _symbol, _quantity, _transaction, _customdata);
-        mainnetRFQ.processXFerPayload(_trader, _symbol, _quantity, _transaction, _customdata);
+        IPortfolio.XFER memory xfer = IPortfolio.XFER(0, _transaction, _trader, _symbol, _quantity, 0, _customdata);
+        mainnetRFQ.processXFerPayload(xfer);
     }
 
     function attackRemoveFromSwapQueue(uint256 _nonceAndMeta) external payable {
@@ -84,7 +85,8 @@ contract MainnetRFQAttacker {
         } else if (functionToAttack == Function.PROCESS_XFER_PAYLOAD) {
             (address _trader, bytes32 _symbol, uint256 _quantity, IPortfolio.Tx _transaction, bytes28 _customdata) = abi
                 .decode(params, (address, bytes32, uint256, IPortfolio.Tx, bytes28));
-            mainnetRFQ.processXFerPayload(_trader, _symbol, _quantity, _transaction, _customdata);
+            IPortfolio.XFER memory xfer = IPortfolio.XFER(0, _transaction, _trader, _symbol, _quantity, 0, _customdata);
+            mainnetRFQ.processXFerPayload(xfer);
         } else if (functionToAttack == Function.REMOVE_FROM_SWAP_QUEUE) {
             uint256 _nonceAndMeta = abi.decode(params, (uint256));
             mainnetRFQ.removeFromSwapQueue(_nonceAndMeta);

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,7 +1,7 @@
 --------------------------------------|----------|----------|----------|----------|----------------|
 File                                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 --------------------------------------|----------|----------|----------|----------|----------------|
- contracts\                           |      100 |    96.52 |      100 |    99.93 |                |
+ contracts\                           |      100 |     96.7 |      100 |      100 |                |
   BannedAccounts.sol                  |      100 |      100 |      100 |      100 |                |
   DelayedTransfers.sol                |      100 |      100 |      100 |      100 |                |
   Exchange.sol                        |      100 |      100 |      100 |      100 |                |
@@ -13,10 +13,10 @@ File                                  |  % Stmts | % Branch |  % Funcs |  % Line
   OrderBooks.sol                      |      100 |      100 |      100 |      100 |                |
   Portfolio.sol                       |      100 |    95.45 |      100 |      100 |                |
   PortfolioBridgeMain.sol             |      100 |    95.37 |      100 |      100 |                |
-  PortfolioBridgeSub.sol              |      100 |       90 |      100 |      100 |                |
+  PortfolioBridgeSub.sol              |      100 |       92 |      100 |      100 |                |
   PortfolioMain.sol                   |      100 |       93 |      100 |      100 |                |
   PortfolioMinter.sol                 |      100 |      100 |      100 |      100 |                |
-  PortfolioSub.sol                    |      100 |    93.09 |      100 |    99.47 |            975 |
+  PortfolioSub.sol                    |      100 |    93.68 |      100 |      100 |                |
   PortfolioSubHelper.sol              |      100 |      100 |      100 |      100 |                |
   TradePairs.sol                      |      100 |    96.82 |      100 |      100 |                |
  contracts\bridgeApps\                |      100 |      100 |      100 |      100 |                |
@@ -57,5 +57,5 @@ File                                  |  % Stmts | % Branch |  % Funcs |  % Line
   TokenVestingCloneFactory.sol        |      100 |      100 |      100 |      100 |                |
   TokenVestingCloneable.sol           |      100 |    96.67 |      100 |      100 |                |
 --------------------------------------|----------|----------|----------|----------|----------------|
-All files                             |    99.86 |    96.71 |      100 |    99.85 |                |
+All files                             |    99.86 |    96.85 |      100 |     99.9 |                |
 --------------------------------------|----------|----------|----------|----------|----------------|

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,7 +1,7 @@
 --------------------------------------|----------|----------|----------|----------|----------------|
 File                                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 --------------------------------------|----------|----------|----------|----------|----------------|
- contracts\                           |      100 |     96.7 |      100 |      100 |                |
+ contracts\                           |      100 |    96.63 |      100 |      100 |                |
   BannedAccounts.sol                  |      100 |      100 |      100 |      100 |                |
   DelayedTransfers.sol                |      100 |      100 |      100 |      100 |                |
   Exchange.sol                        |      100 |      100 |      100 |      100 |                |
@@ -12,8 +12,8 @@ File                                  |  % Stmts | % Branch |  % Funcs |  % Line
   MainnetRFQ.sol                      |      100 |      100 |      100 |      100 |                |
   OrderBooks.sol                      |      100 |      100 |      100 |      100 |                |
   Portfolio.sol                       |      100 |    95.45 |      100 |      100 |                |
-  PortfolioBridgeMain.sol             |      100 |    95.37 |      100 |      100 |                |
-  PortfolioBridgeSub.sol              |      100 |       92 |      100 |      100 |                |
+  PortfolioBridgeMain.sol             |      100 |    95.54 |      100 |      100 |                |
+  PortfolioBridgeSub.sol              |      100 |    90.38 |      100 |      100 |                |
   PortfolioMain.sol                   |      100 |       93 |      100 |      100 |                |
   PortfolioMinter.sol                 |      100 |      100 |      100 |      100 |                |
   PortfolioSub.sol                    |      100 |    93.68 |      100 |      100 |                |
@@ -57,5 +57,5 @@ File                                  |  % Stmts | % Branch |  % Funcs |  % Line
   TokenVestingCloneFactory.sol        |      100 |      100 |      100 |      100 |                |
   TokenVestingCloneable.sol           |      100 |    96.67 |      100 |      100 |                |
 --------------------------------------|----------|----------|----------|----------|----------------|
-All files                             |    99.86 |    96.85 |      100 |     99.9 |                |
+All files                             |    99.86 |     96.8 |      100 |     99.9 |                |
 --------------------------------------|----------|----------|----------|----------|----------------|

--- a/test/MakeTestSuite.ts
+++ b/test/MakeTestSuite.ts
@@ -218,7 +218,7 @@ export const addToken = async (portfolioMain: PortfolioMain , portfolioSub: Port
         Utils.parseUnits(gasSwapRatio.toFixed(tokenDecimals), tokenDecimals), usedForGasSwap);
 
 
-    await addTokenToPortfolioSub(portfolioSub, await token.symbol(), subnetSymbol, token.address, tokenDecimals
+    await addTokenToPortfolioSub(portfolioSub, symbol, subnetSymbol, token.address, tokenDecimals
         , sourceChainID, gasSwapRatio, auctionMode, usedForGasSwap, bridgeFee);
 }
 
@@ -530,7 +530,7 @@ export const deployCompleteMultiChainPortfolio = async (addAvaxChainAlot= false,
     await setRemoteBridges(portfolioBridgeArb, portfolioContracts.portfolioBridgeSub, lzEndpointArb, portfolioContracts.lzEndpointSub, arbitrumChain,dexalotSubnet);
     await setRemoteBridges(portfolioBridgeGun, portfolioContracts.portfolioBridgeSub, lzEndpointGun, portfolioContracts.lzEndpointSub, gunzillaSubnet,dexalotSubnet);
     await setRemoteBridges(portfolioContracts.portfolioBridgeAvax, portfolioBridgeGun, portfolioContracts.lzEndpointAvax, lzEndpointGun, cChain, gunzillaSubnet);
-    await setRemoteBridges(portfolioBridgeArb, portfolioBridgeGun, portfolioContracts.lzEndpointAvax, lzEndpointGun, arbitrumChain, gunzillaSubnet);
+    await setRemoteBridges(portfolioBridgeArb, portfolioBridgeGun, lzEndpointArb, lzEndpointGun, arbitrumChain, gunzillaSubnet);
 
     await portfolioBridgeGun.setUserPaysFeeForDestination(0, cChain.lzChainId, true);
     await portfolioBridgeGun.setUserPaysFeeForDestination(0, arbitrumChain.lzChainId, true);

--- a/test/TestLzDestroyAndRecoverFunds.ts
+++ b/test/TestLzDestroyAndRecoverFunds.ts
@@ -349,7 +349,7 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
         const payload = sp.payloadHash;
 
         // Try a malformed message with xChainMessageNonExistant =5
-        const depositXfer = (await portfolioBridgeSub.getXFerMessage(payload))[0];
+        const depositXfer = (await portfolioBridgeSub.unpackXFerMessage(cChain.chainListOrgId, payload))[0];
         const depositAvaxMessage = ethers.utils.defaultAbiCoder.encode(
             [
                 "uint64",   // nonce,
@@ -376,7 +376,7 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
             ["uint8", "bytes"],
             [xChainMessageNonExistant, depositAvaxMessage]
         )
-        await expect (portfolioBridgeSub.getXFerMessage(MalFormedPayload)).to.revertedWith("call revert exception");
+        await expect (portfolioBridgeSub.unpackXFerMessage(cChain.chainListOrgId, MalFormedPayload)).to.revertedWith("call revert exception");
         expect(await portfolioBridgeSub["hasStoredPayload()"]()).to.be.true;
 
     });
@@ -392,7 +392,7 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
         //replacing 3 with 50
         const amountModifiedPayload = payload.slice(0, 177) + "2B5E3AF16B1880000" + payload.slice(194);
 
-        expect ((await portfolioBridgeMain.getXFerMessage(payload))[1]).to.be.equal(Utils.fromUtf8("AVAX"));
+        expect ((await portfolioBridgeMain.unpackXFerMessage(dexalotSubnet.chainListOrgId, payload))[1]).to.be.equal(Utils.fromUtf8("AVAX"));
         // fail for non-admin
         await expect(portfolioBridgeSub.connect(trader1).lzRetryPayload(cChain.lzChainId, payload)).to.be.revertedWith("AccessControl: account");
 
@@ -469,7 +469,7 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
         //replacing 3 with 50
         const amountModifiedPayload = payload.slice(0, 177) + "2B5E3AF16B1880000" + payload.slice(194);
 
-        expect ((await portfolioBridgeMain.getXFerMessage(payload))[1]).to.be.equal(ALOT);
+        expect ((await portfolioBridgeMain.unpackXFerMessage(cChain.chainListOrgId , payload))[1]).to.be.equal(ALOT);
         // fail for non-admin
         await expect(portfolioBridgeSub.connect(trader1).lzRetryPayload(cChain.lzChainId, payload)).to.be.revertedWith("AccessControl: account");
 

--- a/test/TestLzDestroyAndRecoverFunds.ts
+++ b/test/TestLzDestroyAndRecoverFunds.ts
@@ -307,7 +307,7 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
 
         await expect(portfolioBridgeMain.lzDestroyAndRecoverFunds(dexalotSubnet.lzChainId,
             modifiedPayload
-        )).to.be.revertedWith(`P-ETNS-02`)
+        )).to.be.revertedWith(`PB-ETNS-01`)
 
         await expect(portfolioBridgeMain.lzDestroyAndRecoverFunds(dexalotSubnet.lzChainId,
             amountModifiedPayload
@@ -349,7 +349,7 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
         const payload = sp.payloadHash;
 
         // Try a malformed message with xChainMessageNonExistant =5
-        const depositXfer = (await portfolioBridgeSub.unpackXFerMessage(cChain.chainListOrgId, payload))[0];
+        const depositXfer = await portfolioBridgeSub.unpackXFerMessage(payload);
         const depositAvaxMessage = ethers.utils.defaultAbiCoder.encode(
             [
                 "uint64",   // nonce,
@@ -376,7 +376,7 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
             ["uint8", "bytes"],
             [xChainMessageNonExistant, depositAvaxMessage]
         )
-        await expect (portfolioBridgeSub.unpackXFerMessage(cChain.chainListOrgId, MalFormedPayload)).to.revertedWith("call revert exception");
+        await expect (portfolioBridgeSub.unpackXFerMessage(MalFormedPayload)).to.revertedWith("call revert exception");
         expect(await portfolioBridgeSub["hasStoredPayload()"]()).to.be.true;
 
     });
@@ -391,8 +391,8 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
         const payload = sp.payloadHash;
         //replacing 3 with 50
         const amountModifiedPayload = payload.slice(0, 177) + "2B5E3AF16B1880000" + payload.slice(194);
-
-        expect ((await portfolioBridgeMain.unpackXFerMessage(dexalotSubnet.chainListOrgId, payload))[1]).to.be.equal(Utils.fromUtf8("AVAX"));
+        //console.log(await portfolioBridgeMain.unpackXFerMessage(payload))
+        expect ((await portfolioBridgeMain.unpackXFerMessage(payload))[3]).to.be.equal(Utils.fromUtf8("AVAX"));
         // fail for non-admin
         await expect(portfolioBridgeSub.connect(trader1).lzRetryPayload(cChain.lzChainId, payload)).to.be.revertedWith("AccessControl: account");
 
@@ -469,7 +469,7 @@ describe("LZ Destroy Stuck Message & Recover Funds Functionality", async () => {
         //replacing 3 with 50
         const amountModifiedPayload = payload.slice(0, 177) + "2B5E3AF16B1880000" + payload.slice(194);
 
-        expect ((await portfolioBridgeMain.unpackXFerMessage(cChain.chainListOrgId , payload))[1]).to.be.equal(ALOT);
+        expect ((await portfolioBridgeMain.unpackXFerMessage(payload))[3]).to.be.equal(ALOT);
         // fail for non-admin
         await expect(portfolioBridgeSub.connect(trader1).lzRetryPayload(cChain.lzChainId, payload)).to.be.revertedWith("AccessControl: account");
 

--- a/test/TestPBMainToPBMain.ts
+++ b/test/TestPBMainToPBMain.ts
@@ -111,7 +111,7 @@ describe("Mainnet RFQ Portfolio Bridge Main to Portfolio Bridge Main", () => {
         await f.addVirtualToken(portfolioAvax, gunDetails.symbol, gunDetails.decimals, gunzillaSubnet.chainListOrgId);
         // Add virtual USDC to gunzilla with avalanche Network id (Which is the default destination). But USDC can be
         // sent to Arb as well
-        await f.addVirtualToken(portfolioGun, usdcDetails.symbol, usdcDetails.decimals, cChain.chainListOrgId);
+        //await f.addVirtualToken(portfolioGun, usdcDetails.symbol, usdcDetails.decimals, cChain.chainListOrgId);
         await f.addToken(portfolioAvax, portfolioSub, usdc, 0.5, 0, true, 0);
         await f.addToken(portfolioArb, portfolioSub, usdcArb, 0.5, 0, true, 0);
 
@@ -252,6 +252,11 @@ describe("Mainnet RFQ Portfolio Bridge Main to Portfolio Bridge Main", () => {
                  customdata: Utils.emptyCustomData()
         };
 
+        await expect(portfolioBridgeArb.sendXChainMessage(gunzillaSubnet.chainListOrgId, bridge0, xfer1, trader)).to.be.revertedWith("PB-ETNS-01");
+
+        // Add virtual GUN to avalanche with gunzilla Network id
+        await f.addVirtualToken(portfolioArb, gunDetails.symbol, gunDetails.decimals, gunzillaSubnet.chainListOrgId);
+
         const tx = await portfolioBridgeArb.sendXChainMessage(gunzillaSubnet.chainListOrgId, bridge0, xfer1, trader);
         const receipt: any = await tx.wait();
 
@@ -318,6 +323,9 @@ describe("Mainnet RFQ Portfolio Bridge Main to Portfolio Bridge Main", () => {
 
         const value = await portfolioBridgeGun.getBridgeFee(bridge0, cChain.chainListOrgId, ethers.constants.HashZero, 0);
 
+        await expect(portfolioBridgeGun.sendXChainMessage(cChain.chainListOrgId, bridge0, xfer1, trader, {value: value})).to.be.revertedWith("PB-ETNS-01");
+
+        await f.addVirtualToken(portfolioGun, usdcDetails.symbol, usdcDetails.decimals, cChain.chainListOrgId);
         const tx = await portfolioBridgeGun.sendXChainMessage(cChain.chainListOrgId, bridge0, xfer1, trader, {value: value});
         const receipt: any = await tx.wait();
 
@@ -370,7 +378,10 @@ describe("Mainnet RFQ Portfolio Bridge Main to Portfolio Bridge Main", () => {
         const quantity = Utils.parseUnits("10", usdcDetails.decimals);
         const timestamp = BigNumber.from(await f.latestTime());
 
-        const { arbitrumChain, gunzillaSubnet } = f.getChains();
+        const { cChain, arbitrumChain, gunzillaSubnet } = f.getChains();
+
+        // Adding virtual USDC with cchain chain id , NOT ARB, IT SHOULD NOT MATTER
+        await f.addVirtualToken(portfolioGun, usdcDetails.symbol, usdcDetails.decimals, cChain.chainListOrgId);
 
         await portfolioBridgeGun.grantRole(await portfolioBridgeGun.BRIDGE_USER_ROLE(), owner.address);
 

--- a/test/TestPortfolioBridgeMain.ts
+++ b/test/TestPortfolioBridgeMain.ts
@@ -414,8 +414,7 @@ describe("Portfolio Bridge Main", () => {
                 expect(log.args.remoteChainId).to.be.equal(dexalotSubnet.chainListOrgId);
                 expect(log.args.msgDirection).to.be.equal(0); // 0 SENT 1 RECEIVED
                 expect(log.args.xfer.timestamp).to.be.equal(timestamp); // Timestamp when message is created from above
-                 //For PortfolioBridgeMain, symbol has not changed
-                expect(log.args.xfer.symbol).to.be.equal(symbol);
+
 
             } else if (log.address == portfolioBridgeSub.address) { //Subnet event
                 expect(log.args.remoteChainId).to.be.equal(cChain.chainListOrgId); //message from mainnet
@@ -423,10 +422,10 @@ describe("Portfolio Bridge Main", () => {
                 // timestamp is overwritten at receival block.timestamp
                 const txnBlock = await ethers.provider.getBlock(log.blockNumber);
                 expect(log.args.xfer.timestamp).to.be.equal(txnBlock.timestamp);
-                //unpackXferMessage which maps symbol to symbolId.
-                expect(log.args.xfer.symbol).to.be.equal(symbolId);
             }
 
+            //Symbol is always the source Symbol
+            expect(log.args.xfer.symbol).to.be.equal(symbol);
             expect(log.args.xfer.nonce).to.be.equal(1);
             expect(log.args.xfer.transaction).to.be.equal(transaction1);
             expect(log.args.xfer.trader).to.be.equal(trader);

--- a/test/TestPortfolioBridgeSub.ts
+++ b/test/TestPortfolioBridgeSub.ts
@@ -646,7 +646,6 @@ describe("Portfolio Bridge Sub", () => {
 
     it("Should use executeDelayedTransfer correctly - withdraw", async () => {
         const { admin } = await f.getAccounts();
-        const { cChain} = f.getChains();
 
         await f.setBridgeSubSettings(
             delayedTransfers,
@@ -683,7 +682,7 @@ describe("Portfolio Bridge Sub", () => {
         expect(receipt.events[1].args.xfer.nonce).to.be.equal(1);       // nonce is 1
         expect(receipt.events[1].args.xfer.transaction).to.be.equal(0); // withdraw
         expect(receipt.events[1].args.xfer.trader).to.be.equal(admin.address);
-        expect(receipt.events[1].args.xfer.symbol).to.be.equal(Utils.fromUtf8("AVAX"+ cChain.chainListOrgId));
+        expect(receipt.events[1].args.xfer.symbol).to.be.equal(AVAX);
         expect(receipt.events[1].args.xfer.quantity).to.be.equal(ethers.utils.parseEther("0.51"));
     });
 

--- a/test/TestPortfolioSub.ts
+++ b/test/TestPortfolioSub.ts
@@ -1317,6 +1317,11 @@ describe("Portfolio Sub", () => {
         await f.depositToken(portfolioMain, trader1, usdt, token_decimals, USDT, deposit_amount.toString(), 0);
         expect(await inventoryManager.get(Utils.fromUtf8(orginalSubnetSymbol), origsubnet_symbol_bytes32)).to.be.equal(Utils.toWei(deposit_amount.toString()));
 
+        // console.log("after USDt");
+        // await f.printTokens([portfolioMain], portfolioSub, portfolioBridgeSub);
+        // console.log(subnet_symbol, await inventoryManager.get(Utils.fromUtf8(subnet_symbol), origsubnet_symbol_bytes32));
+        // console.log(orginalSubnetSymbol, await inventoryManager.get(Utils.fromUtf8(orginalSubnetSymbol), origsubnet_symbol_bytes32));
+
         await expect(portfolioSub.connect(trader1).convertToken(Utils.fromUtf8("USDt"))).to.be.revertedWith("P-ETNS-02");
 
         await f.addTokenToPortfolioSub(portfolioSub, cChainSymbol, subnet_symbol, usdt.address, tokenDecimals
@@ -1326,12 +1331,14 @@ describe("Portfolio Sub", () => {
         expect(await portfolioSub.tokenTotals(Utils.fromUtf8(orginalSubnetSymbol))).to.be.equal(Utils.toWei((deposit_amount*2).toString()));
         expect(await portfolioSub.tokenTotals(Utils.fromUtf8(subnet_symbol))).to.be.equal(0);
         expect(await inventoryManager.get(Utils.fromUtf8(orginalSubnetSymbol), origsubnet_symbol_bytes32)).to.be.equal(Utils.toWei((deposit_amount*2).toString()));
-
+        // console.log("after USDt with USDT subnetSYmbol");
+        // await f.printTokens([portfolioMain], portfolioSub, portfolioBridgeSub);
+        // console.log(subnet_symbol, await inventoryManager.get(Utils.fromUtf8(subnet_symbol), origsubnet_symbol_bytes32));
+        // console.log(orginalSubnetSymbol, await inventoryManager.get(Utils.fromUtf8(orginalSubnetSymbol), origsubnet_symbol_bytes32));
 
         // console.log("");
         // console.log("Token totals Orig", orginalSubnetSymbol, await portfolioSub.tokenTotals(Utils.fromUtf8(orginalSubnetSymbol)));
         // console.log("Token totals New", subnet_symbol, await portfolioSub.tokenTotals(Utils.fromUtf8(subnet_symbol)));
-        // console.log("Inventory by id Orig", orginalSubnetSymbol+ cChain.chainListOrgId, await portfolioBridgeSub.inventoryBySymbolId(origsubnet_symbol_bytes32));
 
         // convertion from USTt to USDT is allowed
         await portfolioSubHelper.addConvertibleToken(Utils.fromUtf8("USDt"), Utils.fromUtf8("USDT"));
@@ -1346,7 +1353,7 @@ describe("Portfolio Sub", () => {
         await expect(portfolioSub.connect(trader1).convertToken(Utils.fromUtf8("USDt"))).to.be.revertedWith("P-TFNE-01");
         await portfolioSub.adjustAvailable(3, trader1.address, USDT, Utils.toWei('10'))
 
-        // Convert trader1 positins. They go under the new subnet symbol. trader2' are under the original subnet symbol
+        // Convert trader1 positions. They go under the new subnet symbol. trader2' are under the original subnet symbol
         await portfolioSub.connect(trader1).convertToken(Utils.fromUtf8("USDt"));
 
         // no positions to convert. Owner has 0


### PR DESCRIPTION
- Logic Change: Symbol mapping removed from PortfolioBridgeMain. PortfolioBridgeMain now always sends the ERC20 Symbol
and expects the same back instead of sending symbolId (AVAX43113) back and forth. SymbolId is now resolvedin PortfolioBridgeSub at the time message receival as it knows which chain the message is coming from as well as the source Symbol. PortfolioBridgeSub also resolves the destination symbol per destination chainId at the time when it sends messages back to host chains. This change was necessary to support PortfolioBridgeMain sending CCTRADE messages from GUN to multiple different host chains ( i.e. virtual USDC to be delivered in Arb or Avalanche).
- made sendXChainMessageInternal & processPayload logic more readable
- xfer.symbol now has the source chain symbol in the emitted logs. The symbolId is not going to be shown in the emitted logs after the upgrade.
- renamed getXFerMessage as unpackXFerMessage for consistency (pack/unpack)
- removed redundant messageFee return parameter from sendXChainMessage function
- XChainXFerMessage remoteChainId is now displaying the dstChainListOrgChainId rather than lzdestChainId
- Documentation updated
PortfolioSub:
- updateTokenDetailsAfterUpgrade bug fix, when setting the existing tokens to virtual
- withdrawToken function now checks to see if the symbol should be overridden in case it is in the token conversion list
MainnetRFQ
-processXFerPayload method now expects a single function parameter: IPortfolio.XFER