### PR TITLE
May 2024 Release Candidate

### DIFF
--- a/contracts/InventoryManager.sol
+++ b/contracts/InventoryManager.sol
@@ -24,7 +24,7 @@ contract InventoryManager is AccessControlEnumerableUpgradeable, IInventoryManag
     using EnumerableMap for EnumerableMap.Bytes32ToUintMap;
 
     bytes32 private constant PORTFOLIO_BRIDGE_ROLE = keccak256("PORTFOLIO_BRIDGE_ROLE");
-    bytes32 public constant VERSION = bytes32("3.0.2");
+    bytes32 public constant VERSION = bytes32("3.0.3");
     uint256 private constant STARTING_A = 50;
     uint256 private constant MIN_A = 10;
     uint256 private constant MAX_A = 10 ** 8;
@@ -185,28 +185,6 @@ contract InventoryManager is AccessControlEnumerableUpgradeable, IInventoryManag
                 set(tokenDetails.symbol, _tokens[i], _quantities[i]);
             }
         }
-    }
-
-    /**
-     * @notice  Converts the inventory of a token from one subnet symbol to another
-     * @dev     Only portfolio bridge can call this function
-     * @param   _symbolId  SymbolId of the token
-     * @param   _fromSymbol  Subnet symbol of the token to convert from
-     * @param   _toSymbol  Subnet symbol of the token to convert to
-     */
-    function convertSymbol(
-        bytes32 _symbolId,
-        bytes32 _fromSymbol,
-        bytes32 _toSymbol
-    ) external onlyRole(PORTFOLIO_BRIDGE_ROLE) {
-        require(_fromSymbol != bytes32(0) && _toSymbol != bytes32(0), "IM-SMEB-01");
-        EnumerableMap.Bytes32ToUintMap storage fromMap = inventoryBySubnetSymbol[_fromSymbol];
-        (bool success, uint256 inventory) = fromMap.tryGet(_symbolId);
-        if (success) {
-            fromMap.remove(_symbolId);
-        }
-        uint256 curInventory = get(_toSymbol, _symbolId);
-        inventoryBySubnetSymbol[_toSymbol].set(_symbolId, curInventory + inventory);
     }
 
     /**

--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -47,8 +47,9 @@ abstract contract Portfolio is
     IPortfolio
 {
     using EnumerableSetUpgradeable for EnumerableSetUpgradeable.Bytes32Set;
-    // denominator for rate calculations
-    uint256 public constant TENK = 10000;
+    // denominator for rate calculations. Changed it to 100K from 10K on May 2024 Release to support volume rebates
+    // only used in PortfolioSub
+    uint256 public constant TENK = 100000;
     // boolean to control deposit functionality
     bool public allowDeposit;
 
@@ -271,14 +272,12 @@ abstract contract Portfolio is
         bytes32 _symbol,
         uint32 _srcChainId
     ) public virtual override whenPaused onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (_symbol != native) {
-            tokenList.remove(_symbol);
-            delete (tokenDetailsMap[_symbol]);
-            bytes32 symbolId = UtilsLibrary.getIdForToken(_symbol, _srcChainId);
-            delete (tokenDetailsMapById[symbolId]);
-            delete (bridgeParams[_symbol]);
-            emit ParameterUpdated(_symbol, "P-REMOVETOKEN", 0, 0);
-        }
+        tokenList.remove(_symbol);
+        delete (tokenDetailsMap[_symbol]);
+        bytes32 symbolId = UtilsLibrary.getIdForToken(_symbol, _srcChainId);
+        delete (tokenDetailsMapById[symbolId]);
+        delete (bridgeParams[_symbol]);
+        emit ParameterUpdated(_symbol, "P-REMOVETOKEN", 0, 0);
     }
 
     /**

--- a/contracts/PortfolioSubHelper.sol
+++ b/contracts/PortfolioSubHelper.sol
@@ -22,16 +22,25 @@ import "./interfaces/IPortfolioSubHelper.sol";
 contract PortfolioSubHelper is Initializable, AccessControlEnumerableUpgradeable, IPortfolioSubHelper {
     mapping(address => bool) public adminAccountsForRates;
     mapping(address => string) public organizations;
-    mapping(address => mapping(bytes32 => Rates)) private rateOverrides;
-    mapping(bytes32 => bytes32) private convertableTokens;
-
+    // Preset preferential rates regardless of the trade volumes. Used for contracted market makers
+    mapping(address => mapping(bytes32 => Rates)) public rateOverrides;
+    mapping(bytes32 => bytes32) private convertableTokens; // obsolete
     // version
-    bytes32 public constant VERSION = bytes32("2.5.1");
-
+    bytes32 public constant VERSION = bytes32("2.5.4");
+    uint256 public minTakerRate;
+    // Holds volume based rebates for everyone
+    mapping(address => Rebates) public rebates;
     // storage gap for upgradeability
-    uint256[50] __gap;
+    uint256[48] __gap; //unnecessary
 
-    event AddressSet(string indexed name, string actionName, address addressAdded, bytes32 customData);
+    event RateChanged(
+        string indexed name,
+        string actionName,
+        address addressAdded,
+        bytes32 customData,
+        uint8 maker,
+        uint8 taker
+    );
 
     /**
      * @notice  Initialize the upgradeable contract
@@ -40,6 +49,18 @@ contract PortfolioSubHelper is Initializable, AccessControlEnumerableUpgradeable
         __AccessControl_init();
         // admin account that can call inherited grantRole and revokeRole functions from OpenZeppelin AccessControl
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        minTakerRate = 5;
+    }
+
+    /**
+     * @notice  Sets the minimum Taker rate that is possible after the volume rebates
+     * @dev     Only callable by admin.
+     * @param   _rate  Minimum Taker rate after volume rebates
+     */
+    function setMinTakerRate(uint256 _rate) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(_rate > 0, "P-MTNZ-01");
+        minTakerRate = _rate;
+        emit RateChanged("MIN_TAKER_RATE", "UPDATE", address(0), bytes32(0), 0, uint8(_rate));
     }
 
     /**
@@ -56,7 +77,7 @@ contract PortfolioSubHelper is Initializable, AccessControlEnumerableUpgradeable
         require(_account != address(0), "P-ZADDR-01");
         adminAccountsForRates[_account] = true;
         organizations[_account] = _organization;
-        emit AddressSet("ADMIN_RATES", "ADD", _account, bytes32(0));
+        emit RateChanged("ADMIN_RATES", "ADD", _account, bytes32(0), 0, 0);
     }
 
     /**
@@ -67,7 +88,7 @@ contract PortfolioSubHelper is Initializable, AccessControlEnumerableUpgradeable
     function removeAdminAccountForRates(address _account) external onlyRole(DEFAULT_ADMIN_ROLE) {
         delete adminAccountsForRates[_account];
         delete organizations[_account];
-        emit AddressSet("ADMIN_RATES", "REMOVE", _account, bytes32(0));
+        emit RateChanged("ADMIN_RATES", "REMOVE", _account, bytes32(0), 0, 0);
     }
 
     /**
@@ -79,117 +100,147 @@ contract PortfolioSubHelper is Initializable, AccessControlEnumerableUpgradeable
     }
 
     /**
-     * @notice  Adds the given set of tradepair ids for a given address to rebateAccountsForRates
-     * @dev     Only callable by admin. Rebates are set for each tradepair for a given address
-     * @param   _rebateAddress  Address of rebate account
+     * @notice  Adds the given address to rebates mapping that keeps track of volume based rebates.
+     * @dev     Only callable by admin. Rebates are set for each address. An offchain application
+     * checks the 30 days rolling volume and calculates the discount the address is eligible for.
+     * Pass 0 & 0 maker taker rebates to delete the rebate address from the mapping.
+     * @param   _rebateAddress Array of rebate accounts
+     * @param   _makerRebates Array of maker rebates
+     * @param   _takerRebates Array of taker rebates
+     */
+    function addVolumeBasedRebates(
+        address[] calldata _rebateAddress,
+        uint8[] calldata _makerRebates,
+        uint8[] calldata _takerRebates
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(
+            _rebateAddress.length == _makerRebates.length && _makerRebates.length == _takerRebates.length,
+            "P-LENM-01"
+        );
+        // This is an admin function that will be called a lot.
+        // No requires to save gas
+        for (uint256 i = 0; i < _rebateAddress.length; ++i) {
+            // Ignore address(0) & more than 100% rebate
+            if (_rebateAddress[i] == address(0) || _makerRebates[i] > 100 || _takerRebates[i] > 99) {
+                continue;
+            }
+            // 0 Rebates for the address, remove it from the state.
+            if (_makerRebates[i] == 0 && _takerRebates[i] == 0) {
+                delete rebates[_rebateAddress[i]];
+            } else {
+                Rebates storage rebate = rebates[_rebateAddress[i]];
+                rebate.maker = _makerRebates[i];
+                rebate.taker = _takerRebates[i];
+            }
+            emit RateChanged("REBATES", "UPDATED", _rebateAddress[i], bytes32(0), _makerRebates[i], _takerRebates[i]);
+        }
+    }
+
+    /**
+     * @notice  Adds the given set of tradepairs for a given address to rateOverrides. Usually used
+     * for contracted market makers. (0.20% = 20 bps = 20/10000)
+     * Use 255 for logical deletion of one leg and keep the other leg. If both need to be deleted,
+     * use removeTradePairsFromRateOverrides function
+     * @dev     Only callable by admin. Overrides are set for each tradepair for a given address.
+     * if you pass the max uint8 value 255 to either maker or taker rate, it will use the default maker/taker
+     * this is for situations where you want to have a preferential rate on the maker and also wanting to make
+     * use of volume rebates on the taker side or visa versa
+     * @param   _account  Address for the override to be applied
      * @param   _organization Organization / reason
      * @param   _tradePairIds Array of TradePairIds
      * @param   _makerRates Array of maker rates
      * @param   _takerRates Array of taker rates
      */
-    function addRebateAccountForRates(
-        address _rebateAddress,
+    function addToRateOverrides(
+        address _account,
         string calldata _organization,
         bytes32[] calldata _tradePairIds,
         uint8[] calldata _makerRates,
         uint8[] calldata _takerRates
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_rebateAddress != address(0), "P-ZADDR-01");
-        organizations[_rebateAddress] = _organization;
+        require(_account != address(0), "P-ZADDR-01");
+        organizations[_account] = _organization;
         for (uint256 i = 0; i < _tradePairIds.length; ++i) {
-            Rates storage rate = rateOverrides[_rebateAddress][_tradePairIds[i]];
+            Rates storage rate = rateOverrides[_account][_tradePairIds[i]];
             rate.tradePairId = _tradePairIds[i];
             rate.makerRate = _makerRates[i];
             rate.takerRate = _takerRates[i];
-            emit AddressSet("REBATE_RATES", "ADD", _rebateAddress, _tradePairIds[i]);
+            emit RateChanged("RATE_OVERRIDE", "ADD", _account, _tradePairIds[i], _makerRates[i], _takerRates[i]);
         }
     }
 
     /**
-     * @notice  Removes the a list of tradepairs of an address from rebateAccountsForRates
+     * @notice  Removes the a list of tradepairs of an address from rateOverrides
      * @dev     Only callable by admin
-     * @param   _rebateAddress  Address of the admin account
+     * @param   _account  Address of the admin account
      * @param   _tradePairIds Array of TradePairIds to remove
      */
-    function removeTradePairsFromRebateAccount(
-        address _rebateAddress,
+    function removeTradePairsFromRateOverrides(
+        address _account,
         bytes32[] calldata _tradePairIds
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         for (uint256 i = 0; i < _tradePairIds.length; ++i) {
-            delete rateOverrides[_rebateAddress][_tradePairIds[i]];
-            emit AddressSet("REBATE_RATES", "REMOVE-TRADEPAIR", _rebateAddress, _tradePairIds[i]);
+            delete rateOverrides[_account][_tradePairIds[i]];
+            emit RateChanged("RATE_OVERRIDE", "REMOVE-TRADEPAIR", _account, _tradePairIds[i], 0, 0);
         }
     }
 
     /**
      * @notice  Gets the preferential rates of maker and the taker if any
+     * @dev     255 is used for logical deletion of one leg of preferential rates pair.
+     * Priority 1- check admin rates, 2- preferential rates, 3- Volume Rebates 4- Default rate
+     * Default rates are multiplied by 10 for an additional precision when dealing with default rates
+     * of 1 or 2 bps. Without this, we can't have any rates in between 1 and 2 bps. But with it, we can
+     * have 10(1 bps)-11(1.1 bps)... 19-20(2 bps)
+     * Portfolio.TENK denominator has been multipled by 10 and was changed to 100000 to level the increase.
      * @param   _makerAddr  Maker address of the trade
      * @param   _takerAddr  Taker address of the trade
      * @param   _tradePairId  TradePair Id
-     * @param   _makerRate  tradepair's default maker rate
-     * @param   _takerRate  tradepair's default taker rate
-     * @return   makerRate tradepair's default maker rate or preferential maker rate if any
-     * @return   takerRate tradepair's default taker rate or preferential taker rate if any
+     * @param   _makerRate  tradepair's default maker rate uint8 and < 100
+     * @param   _takerRate  tradepair's default taker rate uint8 and < 100
+     * @return   maker tradepair's default maker rate or discounted rate if any
+     * @return   taker tradepair's default taker rate or discounted rate if any
      */
     function getRates(
         address _makerAddr,
         address _takerAddr,
         bytes32 _tradePairId,
-        uint8 _makerRate,
-        uint8 _takerRate
-    ) external view override returns (uint256 makerRate, uint256 takerRate) {
-        if (adminAccountsForRates[_makerAddr]) {
-            makerRate = 0;
+        uint256 _makerRate,
+        uint256 _takerRate
+    ) external view override returns (uint256 maker, uint256 taker) {
+        if (adminAccountsForRates[_makerAddr] || _makerRate == 0) {
+            maker = 0;
         } else {
-            Rates memory rates = rateOverrides[_makerAddr][_tradePairId];
-            if (rates.tradePairId != bytes32(0)) {
-                makerRate = uint256(rates.makerRate);
+            Rates storage rates = rateOverrides[_makerAddr][_tradePairId];
+            if (rates.tradePairId != bytes32(0) && rates.makerRate != 255) {
+                maker = uint256(rates.makerRate) * 10;
             } else {
-                makerRate = uint256(_makerRate);
+                Rebates storage rebate = rebates[_makerAddr];
+                if (rebate.maker > 0) {
+                    maker = (_makerRate * (100 - rebate.maker)) / 10; // max value is going to be 3 digits
+                } else {
+                    maker = _makerRate * 10;
+                }
             }
         }
 
-        if (adminAccountsForRates[_takerAddr]) {
-            takerRate = 0;
+        if (adminAccountsForRates[_takerAddr] || _takerRate == 0) {
+            taker = 0;
         } else {
-            Rates memory rates = rateOverrides[_takerAddr][_tradePairId];
-            if (rates.tradePairId != bytes32(0)) {
-                takerRate = uint256(rates.takerRate);
+            Rates storage rates = rateOverrides[_takerAddr][_tradePairId];
+            if (rates.tradePairId != bytes32(0) && rates.takerRate != 255) {
+                taker = uint256(rates.takerRate) * 10;
             } else {
-                takerRate = uint256(_takerRate);
+                Rebates storage rebate = rebates[_takerAddr];
+                if (rebate.taker > 0) {
+                    taker = (_takerRate * (100 - rebate.taker)) / 10;
+                    if (taker < minTakerRate) {
+                        taker = minTakerRate; // taker rate can't be less than 0.005%
+                    }
+                } else {
+                    taker = _takerRate * 10;
+                }
             }
         }
-    }
-
-    /**
-     * @notice  Adds a symbol to the convertible symbol mapping
-     * @dev     Only admin can call this function. After the March 2024 upgrade we need to rename
-     * 3 current subnet symbols BTC.b, WETH.e and USDt to BTC, ETH, USDT to support multichain trading.
-     * Tokens to convert to is controlled by the PortfolioSubHelper
-     * All 3 following functions can technically be removed after the March 24 upgrade.
-     * @param   _fromSymbol  Token to be converted from.
-     * @param   _toSymbol   trader address
-     */
-    function addConvertibleToken(bytes32 _fromSymbol, bytes32 _toSymbol) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_fromSymbol != bytes32(0) && _toSymbol != bytes32(0), "P-ZADDR-01");
-        convertableTokens[_fromSymbol] = _toSymbol;
-    }
-
-    /**
-     * @notice  Removes a symbol to the convertible symbol mapping
-     * @dev     Only callable by admin
-     * @param   _fromSymbol  Symbol to remove
-     */
-    function removeConvertibleToken(bytes32 _fromSymbol) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        delete convertableTokens[_fromSymbol];
-    }
-
-    /**
-     * @notice  Gets  a symbol to the convertible symbol mapping
-     * @param   _fromSymbol  From Symbol to be converted
-     * @return  _toSymbol To Symbol
-     */
-    function getSymbolToConvert(bytes32 _fromSymbol) external view override returns (bytes32) {
-        return convertableTokens[_fromSymbol];
     }
 }

--- a/contracts/interfaces/IDelayedTransfers.sol
+++ b/contracts/interfaces/IDelayedTransfers.sol
@@ -11,11 +11,13 @@ pragma solidity 0.8.17;
 // Copyright 2022 Dexalot.
 
 interface IDelayedTransfers {
-    function checkThresholds(IPortfolio.XFER calldata _xfer) external returns (bool);
+    function checkThresholds(IPortfolio.XFER calldata _xfer, uint32 _dstChainListOrgChainId) external returns (bool);
 
     function updateVolume(bytes32 _token, uint256 _amount) external;
 
-    function executeDelayedTransfer(bytes32 _id) external returns (IPortfolio.XFER calldata xfer);
+    function executeDelayedTransfer(
+        bytes32 _id
+    ) external returns (IPortfolio.XFER calldata xfer, uint32 dstChainListOrgChainId);
 
     function setDelayThresholds(bytes32[] calldata _tokens, uint256[] calldata _thresholds) external;
 

--- a/contracts/interfaces/IInventoryManager.sol
+++ b/contracts/interfaces/IInventoryManager.sol
@@ -12,8 +12,6 @@ interface IInventoryManager {
 
     function get(bytes32 _symbol, bytes32 _symbolId) external view returns (uint256);
 
-    function convertSymbol(bytes32 _symbolId, bytes32 _fromSymbol, bytes32 _toSymbol) external;
-
     function calculateWithdrawalFee(
         bytes32 _symbol,
         bytes32 _symbolId,

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -88,6 +88,8 @@ interface IPortfolio {
         ADDGAS,
         REMOVEGAS,
         AUTOFILL, // 10
-        CCTRADE // Cross Chain Trade.
+        CCTRADE, // Cross Chain Trade.
+        CONVERTFROM,
+        CONVERTTO
     }
 }

--- a/contracts/interfaces/IPortfolioBridgeSub.sol
+++ b/contracts/interfaces/IPortfolioBridgeSub.sol
@@ -32,7 +32,7 @@ interface IPortfolioBridgeSub {
 
     function getTokenDetails(bytes32 _symbolId) external view returns (IPortfolio.TokenDetails memory);
 
-    function executeDelayedTransfer(uint16 _dstChainId, bytes32 _id) external;
+    function executeDelayedTransfer(bytes32 _id) external;
 
     function getAllBridgeFees(
         bytes32 _symbol,

--- a/contracts/interfaces/IPortfolioSubHelper.sol
+++ b/contracts/interfaces/IPortfolioSubHelper.sol
@@ -26,11 +26,14 @@ interface IPortfolioSubHelper {
         address _makerAddr,
         address _takerAddr,
         bytes32 _tradePairId,
-        uint8 _makerRate,
-        uint8 _takerRate
-    ) external view returns (uint256 makerRate, uint256 takerRate);
+        uint256 _makerRate,
+        uint256 _takerRate
+    ) external view returns (uint256 maker, uint256 taker);
 
     function isAdminAccountForRates(address _account) external view returns (bool);
 
-    function getSymbolToConvert(bytes32 _fromSymbol) external view returns (bytes32);
+    struct Rebates {
+        uint8 maker;
+        uint8 taker;
+    }
 }

--- a/contracts/mocks/InvariantMathLibraryMock.sol
+++ b/contracts/mocks/InvariantMathLibraryMock.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+import "../library/InvariantMathLibrary.sol";
+
+contract InvariantMathLibraryMock {
+    function calcFees(
+        uint256 A,
+        uint256 quantity,
+        uint256[] calldata inventories,
+        uint256[] calldata scaleFactors,
+        uint256 total
+    ) external pure returns (uint256[] memory) {
+        uint256[] memory fees = new uint256[](inventories.length);
+        for (uint256 i; i < inventories.length; i++) {
+            fees[i] = InvariantMathLibrary.calcWithdrawOneChain(
+                quantity,
+                i,
+                inventories,
+                total,
+                scaleFactors[i],
+                A,
+                inventories.length
+            );
+        }
+        return fees;
+    }
+}

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,7 +1,7 @@
 --------------------------------------|----------|----------|----------|----------|----------------|
 File                                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 --------------------------------------|----------|----------|----------|----------|----------------|
- contracts\                           |      100 |    96.67 |      100 |      100 |                |
+ contracts\                           |      100 |    96.77 |      100 |      100 |                |
   BannedAccounts.sol                  |      100 |      100 |      100 |      100 |                |
   DelayedTransfers.sol                |      100 |      100 |      100 |      100 |                |
   Exchange.sol                        |      100 |      100 |      100 |      100 |                |
@@ -11,12 +11,12 @@ File                                  |  % Stmts | % Branch |  % Funcs |  % Line
   InventoryManager.sol                |      100 |      100 |      100 |      100 |                |
   MainnetRFQ.sol                      |      100 |      100 |      100 |      100 |                |
   OrderBooks.sol                      |      100 |      100 |      100 |      100 |                |
-  Portfolio.sol                       |      100 |    95.83 |      100 |      100 |                |
+  Portfolio.sol                       |      100 |    95.65 |      100 |      100 |                |
   PortfolioBridgeMain.sol             |      100 |    95.69 |      100 |      100 |                |
-  PortfolioBridgeSub.sol              |      100 |    93.55 |      100 |      100 |                |
-  PortfolioMain.sol                   |      100 |    92.71 |      100 |      100 |                |
+  PortfolioBridgeSub.sol              |      100 |     93.1 |      100 |      100 |                |
+  PortfolioMain.sol                   |      100 |    93.52 |      100 |      100 |                |
   PortfolioMinter.sol                 |      100 |      100 |      100 |      100 |                |
-  PortfolioSub.sol                    |      100 |    92.55 |      100 |      100 |                |
+  PortfolioSub.sol                    |      100 |    92.53 |      100 |      100 |                |
   PortfolioSubHelper.sol              |      100 |      100 |      100 |      100 |                |
   TradePairs.sol                      |      100 |    96.82 |      100 |      100 |                |
  contracts\bridgeApps\                |      100 |      100 |      100 |      100 |                |
@@ -48,14 +48,15 @@ File                                  |  % Stmts | % Branch |  % Funcs |  % Line
   UtilsLibrary.sol                    |      100 |      100 |      100 |      100 |                |
  contracts\others\                    |      100 |      100 |      100 |      100 |                |
   Multicall2.sol                      |      100 |      100 |      100 |      100 |                |
- contracts\token\                     |      100 |    95.98 |      100 |      100 |                |
+ contracts\token\                     |      100 |    95.97 |      100 |      100 |                |
   Airdrop.sol                         |      100 |      100 |      100 |      100 |                |
   DexalotToken.sol                    |      100 |      100 |      100 |      100 |                |
   IncentiveDistributor.sol            |      100 |      100 |      100 |      100 |                |
   MockToken.sol                       |      100 |      100 |      100 |      100 |                |
+  MockWrappedToken.sol                |      100 |    95.45 |      100 |      100 |                |
   Staking.sol                         |      100 |    88.71 |      100 |      100 |                |
   TokenVestingCloneFactory.sol        |      100 |      100 |      100 |      100 |                |
   TokenVestingCloneable.sol           |      100 |    96.67 |      100 |      100 |                |
 --------------------------------------|----------|----------|----------|----------|----------------|
-All files                             |    99.87 |    96.82 |      100 |     99.9 |                |
+All files                             |    99.87 |    96.88 |      100 |     99.9 |                |
 --------------------------------------|----------|----------|----------|----------|----------------|

--- a/errors.json
+++ b/errors.json
@@ -59,6 +59,10 @@
     "P-BANA-01": "Portfolio: account banned",
     "P-MDML-01": "Portfolio: minimum deposit multipler can not be less than 10 (10/10)",
     "P-NFUN-01": "Portfolio: unknown function call",
+    "P-TNBC-01": "Portfolio: token not been converted",
+    "P-LENM-01": "Portfolio: length mismatch in array type function parameters",
+    "P-MTNZ-01": "Portfolio: min taker rate can not be 0",
+    "P-NDNS-01": "Portfolio: native deposits not supported",
 
     "PB-OACC-01": "PortfolioBridge: admin account or PORTFOLIO_ROLE needed for this function",
     "PB-RBNE-01": "PortfolioBridge: requested bridge not enabled",

--- a/test/MakeTestSuite.ts
+++ b/test/MakeTestSuite.ts
@@ -33,6 +33,7 @@ import {
     NativeMinterMock,
     LZEndpointMock__factory,
     InventoryManager,
+    MockWrappedToken,
 } from '../typechain-types'
 
 // import { NativeMinterMock } from "../typechain-types/contracts/mocks";
@@ -124,7 +125,12 @@ export const deployDexalotToken = async (): Promise<DexalotToken> => {
 export const deployMockToken = async (tokenStr: string, tokenDecimals: number): Promise<MockToken> => {
     const MockToken = await ethers.getContractFactory("MockToken");
     const mockToken: MockToken = await MockToken.deploy("Mock " + tokenStr + " Token", tokenStr, tokenDecimals) as MockToken;
+    return mockToken;
+}
 
+export const deployMockWrappedToken = async (tokenStr: string, tokenDecimals: number): Promise<MockWrappedToken> => {
+    const MockToken = await ethers.getContractFactory("MockWrappedToken");
+    const mockToken: MockWrappedToken = await MockToken.deploy("Mock Wrapped " + tokenStr + " Token", tokenStr, tokenDecimals) as MockWrappedToken;
     return mockToken;
 }
 

--- a/test/TestInventoryManager.ts
+++ b/test/TestInventoryManager.ts
@@ -88,8 +88,8 @@ describe("InventoryManager", () => {
     .to.be.revertedWith("AccessControl:");
     await expect(inventoryManager.remove(ethers.constants.HashZero, ethers.constants.HashZero))
     .to.be.revertedWith("AccessControl:");
-    await expect(inventoryManager.convertSymbol(ethers.constants.HashZero, ethers.constants.HashZero, ethers.constants.HashZero))
-    .to.be.revertedWith("AccessControl:");
+    // await expect(inventoryManager.convertSymbol(ethers.constants.HashZero, ethers.constants.HashZero, ethers.constants.HashZero))
+    // .to.be.revertedWith("AccessControl:");
   });
 
   it("Should fail to set inventory if not Admin", async function () {
@@ -218,33 +218,34 @@ describe("InventoryManager", () => {
     expect(await inventoryManager.get(NEX, NonExistentId)).to.be.equal(0);
   });
 
-  it("Should fail to convert symbol if empty symbol", async () => {
-    await inventoryManager.grantRole(await portfolioSub.PORTFOLIO_BRIDGE_ROLE(), owner.address);
-    await expect(inventoryManager.convertSymbol(ethers.constants.HashZero, ethers.constants.HashZero, ethers.constants.HashZero))
-    .to.be.revertedWith("IM-SMEB-01");
-    await expect(inventoryManager.convertSymbol(ethers.constants.HashZero, Utils.fromUtf8("USDC"), ethers.constants.HashZero))
-    .to.be.revertedWith("IM-SMEB-01");
-  });
+  // it("Should fail to convert symbol if empty symbol", async () => {
+  //   await inventoryManager.grantRole(await portfolioSub.PORTFOLIO_BRIDGE_ROLE(), owner.address);
+  //   await expect(inventoryManager.convertSymbol(ethers.constants.HashZero, ethers.constants.HashZero, ethers.constants.HashZero))
+  //   .to.be.revertedWith("IM-SMEB-01");
+  //   await expect(inventoryManager.convertSymbol(ethers.constants.HashZero, Utils.fromUtf8("USDC"), ethers.constants.HashZero))
+  //   .to.be.revertedWith("IM-SMEB-01");
+  // });
 
-  it("Should successfully convert symbol if no inventory", async () => {
-    await inventoryManager.grantRole(await portfolioSub.PORTFOLIO_BRIDGE_ROLE(), owner.address);
-    await expect(inventoryManager.convertSymbol(usdcAvax, usdcHex, Utils.fromUtf8("NEW")))
-    .to.not.be.reverted;
-  });
+  // it("Should successfully convert symbol if no inventory", async () => {
+  //   await inventoryManager.grantRole(await portfolioSub.PORTFOLIO_BRIDGE_ROLE(), owner.address);
+  //   await expect(inventoryManager.convertSymbol(usdcAvax, usdcHex, Utils.fromUtf8("NEW")))
+  //   .to.not.be.reverted;
+  // });
 
-  it("Should successfully convert symbol if inventory", async () => {
-    await inventoryManager.grantRole(await portfolioSub.PORTFOLIO_BRIDGE_ROLE(), owner.address);
-    await f.depositToken(portfolioAvax, trader1, mockUSDC, usdcDecimals, usdcHex, "100000");
+  // it("Should successfully convert symbol if inventory", async () => {
+  //   await inventoryManager.grantRole(await portfolioSub.PORTFOLIO_BRIDGE_ROLE(), owner.address);
+  //   await f.depositToken(portfolioAvax, trader1, mockUSDC, usdcDecimals, usdcHex, "100000");
 
-    const depositQuantity = Utils.parseUnits("100000", usdcDecimals);
-    expect(await inventoryManager.get(usdcHex, usdcAvax)).to.be.equal(depositQuantity);
+  //   const depositQuantity = Utils.parseUnits("100000", usdcDecimals);
+  //   expect(await inventoryManager.get(usdcHex, usdcAvax)).to.be.equal(depositQuantity);
 
-    const newToken = Utils.fromUtf8("NEW");
-    await expect(inventoryManager.convertSymbol(usdcAvax, usdcHex, newToken))
-    .to.not.be.reverted;
-    expect(await inventoryManager.get(usdcHex, usdcAvax)).to.be.equal(0);
-    expect(await inventoryManager.get(newToken, usdcAvax)).to.be.equal(depositQuantity);
-  });
+  //   const newToken = Utils.fromUtf8("NEW");
+  //   await expect(inventoryManager.convertSymbol(usdcAvax, usdcHex, newToken))
+  //   .to.not.be.reverted;
+  //   expect(await inventoryManager.get(usdcHex, usdcAvax)).to.be.equal(0);
+  //   expect(await inventoryManager.get(newToken, usdcAvax)).to.be.equal(depositQuantity);
+  // });
+
 
   it("Should fail to get withdrawal fee for multiple chain if quantity exceeds inventory", async () => {
     await f.depositToken(portfolioAvax, trader1, mockUSDC, usdcDecimals, usdcHex, "100000");

--- a/test/TestMockWrappedToken.ts
+++ b/test/TestMockWrappedToken.ts
@@ -6,19 +6,20 @@ import Utils from './utils';
 
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
-import { MockToken } from "../typechain-types";
+import { MockWrappedToken } from "../typechain-types";
 
 import * as f from "./MakeTestSuite";
 
 import { expect } from "chai";
+import { ethers } from 'ethers';
 
-describe("MockToken", () => {
+describe("MockWrappedToken", () => {
 
     let owner: SignerWithAddress;
     let admin: SignerWithAddress;
     let trader1: SignerWithAddress;
     let minter1: SignerWithAddress;
-    let mock: MockToken;
+    let mock: MockWrappedToken;
 
     before(async () => {
         // nothing to be done here
@@ -30,12 +31,13 @@ describe("MockToken", () => {
         admin = admin1;
         trader1 = trader1_;
         minter1 = trader2_;
+        mock = await f.deployMockWrappedToken("WMTOK", 18);
     });
 
     it("Should deploy correctly", async function () {
-        mock = await f.deployMockToken("MTOK", 18);
-        expect(await mock.name()).to.be.equal("Mock MTOK Token");
-        expect(await mock.symbol()).to.be.equal("MTOK");
+
+        expect(await mock.name()).to.be.equal("Mock Wrapped WMTOK Token");
+        expect(await mock.symbol()).to.be.equal("WMTOK");
         expect(await mock.decimals()).to.be.equal(18);
         expect(await mock.totalSupply()).to.be.equal(0);
     });
@@ -43,23 +45,17 @@ describe("MockToken", () => {
     it("Should set up the admin and minter roles correctly", async function () {
         const DEFAULT_ADMIN_ROLE = "0x0000000000000000000000000000000000000000000000000000000000000000";
         const MINTER_ROLE = "0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6";
-        mock = await f.deployMockToken("MTOK", 18);
+
         expect(await mock.getRoleMemberCount(DEFAULT_ADMIN_ROLE)).to.be.equal(1);
         expect(await mock.getRoleMemberCount(MINTER_ROLE)).to.be.equal(1);
         expect(await mock.getRoleMember(DEFAULT_ADMIN_ROLE, 0)).to.be.equal(owner.address);
         expect(await mock.getRoleMember(MINTER_ROLE, 0)).to.be.equal(owner.address);
     });
 
-    it("Should rename token if needed", async function () {
-        mock = await f.deployMockToken("MTOK", 18);
-        await expect(mock.connect(trader1).renameSymbol("MTK")).to.be.revertedWith("AccessControl: account");
-        await mock.renameSymbol("MTK");
-        expect(await mock.symbol()).to.be.equal("MTK");
-    });
 
     it("Should allow adding and removing admin from owner account", async function () {
         const ZERO = '0x0000000000000000000000000000000000000000';
-        mock = await f.deployMockToken("MTOK", 18);
+
         // fail to add for non admin account
         await expect(mock.connect(trader1).addAdmin(admin.address)).to.revertedWith("M-OACC-01");
         // fail to add zero address as admin
@@ -80,7 +76,7 @@ describe("MockToken", () => {
     it("Should allow adding and removing minter from owner account", async function () {
         const MINTER_ROLE = "0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6";
         const ZERO = '0x0000000000000000000000000000000000000000';
-        mock = await f.deployMockToken("MTOK", 18);
+
         // fail to add for non admin account
         await expect(mock.connect(trader1).addMinter(minter1.address)).to.revertedWith("M-OACC-03");
         // fail to add zero address as minter
@@ -97,7 +93,7 @@ describe("MockToken", () => {
     });
 
     it("Should mint correctly from minter account increasing total supply", async function () {
-        mock = await f.deployMockToken("MTOK", 18);
+
         // fail from non-minter
         await expect(mock.connect(trader1).mint(trader1.address, Utils.toWei(parseInt(10e6.toString()).toString())))
             .to.be.revertedWith("AccessControl:");
@@ -108,11 +104,36 @@ describe("MockToken", () => {
     });
 
     it("Should send from owner to another address", async function () {
-        mock = await f.deployMockToken("MTOK", 18);
+
         await mock.connect(owner).mint(owner.address, Utils.toWei(parseInt(100e6.toString()).toString()));
         await mock.connect(owner).transfer(trader1.address, Utils.toWei(parseInt(20e6.toString()).toString()));
         expect(await mock.balanceOf(owner.address)).to.be.equal(Utils.toWei(parseInt(80e6.toString()).toString()));
         expect(await mock.balanceOf(trader1.address)).to.be.equal(Utils.toWei(parseInt(20e6.toString()).toString()));
         expect(await mock.totalSupply()).to.be.equal(Utils.toWei(parseInt(100e6.toString()).toString()));
     });
+
+    it("Should wrap correctly", async function () {
+
+        const amount = "10"
+        expect (await mock.connect(trader1).deposit({value: Utils.toWei(amount),
+            gasLimit: 700000, maxFeePerGas: ethers.utils.parseUnits("5", "gwei")})).to.emit(mock, "Deposit")
+            .withArgs(trader1.address, Utils.toWei(amount));
+        expect(await mock.balanceOf(trader1.address)).to.be.equal(Utils.toWei(amount));
+        expect(await mock.totalSupply()).to.be.equal(Utils.toWei(amount));
+    });
+
+    it("Should unwrap correctly", async function () {
+        const amount = "10"
+        const wad ="5"
+        expect (await mock.connect(trader1).deposit({value: Utils.toWei(amount),
+            gasLimit: 700000, maxFeePerGas: ethers.utils.parseUnits("5", "gwei")})).to.emit(mock, "Deposit")
+            .withArgs(trader1.address, Utils.toWei(amount));
+        // not enough balance
+        await expect( mock.connect(trader1).withdraw(Utils.toWei("15"))).to.be.revertedWith("Insufficient balance");
+
+        expect (await mock.connect(trader1).withdraw(Utils.toWei(wad))).to.emit(mock, "Withdrawal")
+            .withArgs(trader1.address, Utils.toWei(wad));
+        expect(await mock.totalSupply()).to.be.equal(Utils.toWei(wad)); //10 - 5 = 5
+    });
+
 });

--- a/test/TestPortfolioSubHelper.ts
+++ b/test/TestPortfolioSubHelper.ts
@@ -15,7 +15,7 @@ describe("PortfolioSubHelper", () => {
     const AVAX = Utils.fromUtf8("AVAX");
     const ALOT = Utils.fromUtf8("ALOT");
     const BTC = Utils.fromUtf8("BTC");
-    const BTCb = Utils.fromUtf8("BTCb");
+
 
     const tradePairIds = [AVAX, ALOT ];
     const makerRates = [5, 12];
@@ -23,11 +23,34 @@ describe("PortfolioSubHelper", () => {
     const defaultMaker = 20;
     const defaultTaker = 30;
 
+    const makerRebates = [9, 39, 89]; //9%, 39%, 89%
+    const takerRebates = [5, 48, 74]; //5%, 48%, 74%
+
+    // Based on Default Maker Taker Rates
+    const expectedMakerRebateFromDefault = [182, 122, 22]; //0.182% = 20 * (100-9) / 10
+    const expectedTakerRebateFromDefault = [285, 156, 78]; //0.285% = 30 * (100-5) / 10
+
+
+    //Proposed Maker/Taker Rates
+    const proposedMaker = 10
+    const proposedTaker = 12
+
+    const expectedMakerRebateFromProposed = [91, 61, 11];  //0.091% = 10 * (100-9) / 10
+    const expectedTakerRebateFromProposed = [114, 62, 31]; //0.114%, 0.062%, 0.031%,
+
+
     let trader1:SignerWithAddress;
+    let trader2: SignerWithAddress;
+    let other1: SignerWithAddress;
+    let traders: string[];
 
     before(async function () {
         const accounts = await f.getAccounts()
         trader1 = accounts.trader1;
+        trader2 = accounts.trader2;
+        other1 = accounts.other1;
+
+        traders = [trader1.address, trader2.address, other1.address];
     });
 
     beforeEach(async function () {
@@ -40,13 +63,29 @@ describe("PortfolioSubHelper", () => {
     it("Should deploy correctly", async () => {
         const { owner } = await f.getAccounts();
         expect(await portfolioSubHelper.hasRole(await portfolioSubHelper.DEFAULT_ADMIN_ROLE(), owner.address)).to.be.true;
-
+        expect(await portfolioSubHelper.minTakerRate()).to.be.equal(5);
     });
 
     it("Should not initialize again after deployment", async function () {
 
         await expect(portfolioSubHelper.initialize())
             .to.be.revertedWith("Initializable: contract is already initialized");
+    });
+
+
+    it("Should set min Taker rate correctly", async function () {
+        // fail for non owner
+        await expect(portfolioSubHelper.connect(trader1).setMinTakerRate(10))
+            .to.be.revertedWith("AccessControl");
+
+        await expect(portfolioSubHelper.setMinTakerRate(0))
+            .to.be.revertedWith("P-MTNZ-01");
+
+        // succeed for owner
+        await expect(portfolioSubHelper.setMinTakerRate(10))
+            .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("MIN_TAKER_RATE", "UPDATE", ethers.constants.AddressZero, ethers.constants.HashZero, 0, 10);
+        expect(await portfolioSubHelper.minTakerRate()).to.be.equal(10);
     });
 
     it("Should add & remove admin accounts for rates correctly", async () => {
@@ -60,143 +99,219 @@ describe("PortfolioSubHelper", () => {
 
         // succeed for owner
         await expect(portfolioSubHelper.addAdminAccountForRates(trader1.address, "trader1"))
-            .to.emit(portfolioSubHelper, "AddressSet")
-            .withArgs("ADMIN_RATES", "ADD", trader1.address, ethers.constants.HashZero);
+            .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("ADMIN_RATES", "ADD", trader1.address, ethers.constants.HashZero,0,0);
         expect(await portfolioSubHelper.adminAccountsForRates(trader1.address)).to.be.true;
         expect(await portfolioSubHelper.isAdminAccountForRates(trader1.address)).to.be.true;
 
 
         let rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(0);
-        expect(rates.takerRate).to.be.equal(0);
+        expect(rates.maker).to.be.equal(0);
+        expect(rates.taker).to.be.equal(0);
 
         rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, ALOT, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(0);
-        expect(rates.takerRate).to.be.equal(0);
+        expect(rates.maker).to.be.equal(0);
+        expect(rates.taker).to.be.equal(0);
 
         // fail for non owner
         await expect(portfolioSubHelper.connect(trader1).removeAdminAccountForRates(trader1.address))
             .to.be.revertedWith("AccessControl");
 
         await expect(portfolioSubHelper.removeAdminAccountForRates(trader1.address))
-            .to.emit(portfolioSubHelper, "AddressSet")
-            .withArgs("ADMIN_RATES", "REMOVE", trader1.address, ethers.constants.HashZero);
+            .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("ADMIN_RATES", "REMOVE", trader1.address, ethers.constants.HashZero,0,0);
         expect(await portfolioSubHelper.adminAccountsForRates(trader1.address)).to.be.false;
         expect(await portfolioSubHelper.isAdminAccountForRates(trader1.address)).to.be.false;
 
         rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(defaultMaker);
-        expect(rates.takerRate).to.be.equal(defaultTaker);
+        expect(rates.maker).to.be.equal(defaultMaker * 10);
+        expect(rates.taker).to.be.equal(defaultTaker * 10);
 
     })
 
-    it("Should add rebates accounts correctly", async () => {
+    it("Should add rate override accounts correctly", async () => {
 
         let rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(defaultMaker);
-        expect(rates.takerRate).to.be.equal(defaultTaker);
+        expect(rates.maker).to.be.equal(defaultMaker * 10);
+        expect(rates.taker).to.be.equal(defaultTaker * 10);
 
         // fail for account without DEFAULT_ADMIN
-        await expect(portfolioSubHelper.connect(trader1).addRebateAccountForRates(trader1.address, "trader1", tradePairIds, makerRates, takerRates))
+        await expect(portfolioSubHelper.connect(trader1).addToRateOverrides(trader1.address, "trader1", tradePairIds, makerRates, takerRates))
             .to.be.revertedWith("AccessControl");
         expect(await portfolioSubHelper.organizations(trader1.address)).to.be.equal("");
 
-        await expect(portfolioSubHelper.addRebateAccountForRates(ethers.constants.AddressZero, "trader1", tradePairIds, makerRates, takerRates)).to.be.revertedWith("P-ZADDR-01");
+        await expect(portfolioSubHelper.addToRateOverrides(ethers.constants.AddressZero, "trader1", tradePairIds, makerRates, takerRates)).to.be.revertedWith("P-ZADDR-01");
         // succeed for owner
-        await expect(portfolioSubHelper.addRebateAccountForRates(trader1.address, "trader1", tradePairIds, makerRates, takerRates))
-            .to.emit(portfolioSubHelper, "AddressSet")
-            .withArgs("REBATE_RATES", "ADD", trader1.address, AVAX);
+        await expect(portfolioSubHelper.addToRateOverrides(trader1.address, "trader1", tradePairIds, makerRates, takerRates))
+            .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("RATE_OVERRIDE", "ADD", trader1.address, AVAX, makerRates[0], takerRates[0]);
 
         expect(await portfolioSubHelper.organizations(trader1.address)).to.be.equal("trader1");
         rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
         //console.log (rates)
-        expect(rates.makerRate).to.be.equal(makerRates[0]);
-        expect(rates.takerRate).to.be.equal(takerRates[0]);
+        expect(rates.maker).to.be.equal(makerRates[0] * 10);
+        expect(rates.taker).to.be.equal(takerRates[0] * 10);
 
         rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, ALOT, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(makerRates[1]);
-        expect(rates.takerRate).to.be.equal(takerRates[1]);
+        expect(rates.maker).to.be.equal(makerRates[1] * 10);
+        expect(rates.taker).to.be.equal(takerRates[1] * 10);
 
     })
 
     it("Should remove tradpairs from rebates accounts for a given account correctly", async () => {
 
 
-        await expect(portfolioSubHelper.addRebateAccountForRates(trader1.address, "trader1", tradePairIds, makerRates, takerRates))
-        .to.emit(portfolioSubHelper, "AddressSet")
-            .withArgs("REBATE_RATES", "ADD", trader1.address, AVAX);
+        await expect(portfolioSubHelper.addToRateOverrides(trader1.address, "trader1", tradePairIds, makerRates, takerRates))
+        .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("RATE_OVERRIDE", "ADD", trader1.address, AVAX, makerRates[0], takerRates[0]);
 
         //Fail for non owner
-        await expect(portfolioSubHelper.connect(trader1).removeTradePairsFromRebateAccount(trader1.address, tradePairIds)).to.be.revertedWith("AccessControl");
+        await expect(portfolioSubHelper.connect(trader1).removeTradePairsFromRateOverrides(trader1.address, tradePairIds)).to.be.revertedWith("AccessControl");
         // No changes
         expect(await portfolioSubHelper.organizations(trader1.address)).to.be.equal("trader1");
         let rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(makerRates[0]);
-        expect(rates.takerRate).to.be.equal(takerRates[0]);
+        expect(rates.maker).to.be.equal(makerRates[0]*10);
+        expect(rates.taker).to.be.equal(takerRates[0]*10);
 
         rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, ALOT, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(makerRates[1]);
-        expect(rates.takerRate).to.be.equal(takerRates[1]);
+        expect(rates.maker).to.be.equal(makerRates[1]*10);
+        expect(rates.taker).to.be.equal(takerRates[1]*10);
 
 
-        await expect(portfolioSubHelper.removeTradePairsFromRebateAccount(trader1.address, [AVAX]))
-        .to.emit(portfolioSubHelper, "AddressSet")
-            .withArgs("REBATE_RATES", "REMOVE-TRADEPAIR", trader1.address, AVAX);
+        await expect(portfolioSubHelper.removeTradePairsFromRateOverrides(trader1.address, [AVAX]))
+        .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("RATE_OVERRIDE", "REMOVE-TRADEPAIR", trader1.address, AVAX,0,0);
 
         expect(await portfolioSubHelper.organizations(trader1.address)).to.be.equal("trader1");
 
         rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(defaultMaker);
-        expect(rates.takerRate).to.be.equal(defaultTaker);
+        expect(rates.maker).to.be.equal(defaultMaker*10);
+        expect(rates.taker).to.be.equal(defaultTaker*10);
 
         rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, ALOT, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(makerRates[1]);
-        expect(rates.takerRate).to.be.equal(takerRates[1]);
+        expect(rates.maker).to.be.equal(makerRates[1]*10);
+        expect(rates.taker).to.be.equal(takerRates[1]*10);
 
 
-        await expect(portfolioSubHelper.removeTradePairsFromRebateAccount(trader1.address, [ALOT]))
-        .to.emit(portfolioSubHelper, "AddressSet")
-            .withArgs("REBATE_RATES", "REMOVE-TRADEPAIR", trader1.address, ALOT);
+        await expect(portfolioSubHelper.removeTradePairsFromRateOverrides(trader1.address, [ALOT]))
+        .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("RATE_OVERRIDE", "REMOVE-TRADEPAIR", trader1.address, ALOT,0,0);
 
         //Removing the tradepair without using  removeRebateAccountForRates but we get back the default rates
         expect(await portfolioSubHelper.organizations(trader1.address)).to.be.equal("trader1");
 
         rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, ALOT, defaultMaker, defaultTaker);
-        expect(rates.makerRate).to.be.equal(defaultMaker);
-        expect(rates.takerRate).to.be.equal(defaultTaker);
+        expect(rates.maker).to.be.equal(defaultMaker*10);
+        expect(rates.taker).to.be.equal(defaultTaker*10);
 
     })
 
-    it("Should add convertible tokens correctly ", async () => {
+    it("Should market maker get preferential rate on maker & volume rebate on the taker", async () => {
+        let rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
+        expect(rates.maker).to.be.equal(defaultMaker * 10);
+        expect(rates.taker).to.be.equal(defaultTaker * 10);
 
-        // fail for non owner
-        await expect(portfolioSubHelper.connect(trader1).addConvertibleToken(BTCb, BTC))
+        await expect(portfolioSubHelper.addToRateOverrides(trader1.address, "trader1", tradePairIds, makerRates, takerRates))
+        .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("RATE_OVERRIDE", "ADD", trader1.address, AVAX, makerRates[0], takerRates[0]);
+
+        //Delete ALOT taker rate with 255
+        await expect(portfolioSubHelper.addToRateOverrides(trader1.address, "trader1", [ALOT], [makerRates[1]], [255]))
+        .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("RATE_OVERRIDE", "ADD", trader1.address, ALOT, makerRates[1], 255);
+
+        rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, ALOT, defaultMaker, defaultTaker);
+        expect(rates.maker).to.be.equal(makerRates[1] * 10);
+        expect(rates.taker).to.be.equal(defaultTaker * 10);
+
+        //Set Volume Rebates for taker
+        await expect(portfolioSubHelper.addVolumeBasedRebates([trader1.address], [makerRebates[0]], [takerRebates[0]]))
+        .to.emit(portfolioSubHelper, "RateChanged")
+        .withArgs("REBATES", "UPDATED", trader1.address, ethers.constants.HashZero, makerRebates[0], takerRebates[0]);
+
+        rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, ALOT, defaultMaker, defaultTaker);
+        expect(rates.maker).to.be.equal(makerRates[1] * 10); // returns the preferential rate , not the volume
+        expect(rates.taker).to.be.equal(expectedTakerRebateFromDefault[0]);
+
+
+        //Delete AVAX taker rate with 255
+        await expect(portfolioSubHelper.addToRateOverrides(trader1.address, "trader1", [AVAX], [255], [takerRates[0]]))
+        .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("RATE_OVERRIDE", "ADD", trader1.address, AVAX, 255, takerRates[0]);
+
+        //Volume Rebates for maker is still active
+
+        rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
+        expect(rates.maker).to.be.equal(expectedMakerRebateFromDefault[0]);
+        expect(rates.taker).to.be.equal(takerRates[0] * 10 ); // returns the preferential rate , not the volume
+
+
+    })
+
+    it("Should add volume based rebates correctly", async () => {
+
+        let rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, defaultMaker, defaultTaker);
+        expect(rates.maker).to.be.equal(defaultMaker * 10);
+        expect(rates.taker).to.be.equal(defaultTaker * 10);
+
+        rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, AVAX, 0, 0);
+        expect(rates.maker).to.be.equal(0);
+        expect(rates.taker).to.be.equal(0);
+
+        // fail for account without DEFAULT_ADMIN
+        await expect(portfolioSubHelper.connect(trader1).addVolumeBasedRebates(traders,  makerRebates, takerRebates))
             .to.be.revertedWith("AccessControl");
 
-        await expect(portfolioSubHelper.addConvertibleToken(ethers.constants.HashZero, BTC))
-            .to.be.revertedWith("P-ZADDR-01");
-        await expect(portfolioSubHelper.addConvertibleToken(BTCb, ethers.constants.HashZero))
-            .to.be.revertedWith("P-ZADDR-01");
+        await expect(portfolioSubHelper.addVolumeBasedRebates([ethers.constants.AddressZero],  makerRebates, takerRebates))
+            .to.be.revertedWith("P-LENM-01");
 
-        await portfolioSubHelper.addConvertibleToken(BTCb, BTC);
+        //Silent fail for 0 address
+        await portfolioSubHelper.addVolumeBasedRebates([ethers.constants.AddressZero], [makerRebates[0]], [takerRebates[0]]);
+        await portfolioSubHelper.addVolumeBasedRebates([trader1.address], [101], [12]); // maker >100
+        await portfolioSubHelper.addVolumeBasedRebates([trader1.address], [10], [100]); // taker >99
 
-        expect( await portfolioSubHelper.getSymbolToConvert(BTCb)).to.be.equal(BTC);
 
+        // succeed for owner
+        await expect(portfolioSubHelper.addVolumeBasedRebates(traders,  makerRebates, takerRebates))
+            .to.emit(portfolioSubHelper, "RateChanged")
+            .withArgs("REBATES", "UPDATED", trader1.address, ethers.constants.HashZero, makerRebates[0], takerRebates[0]);
+
+
+
+        let i = 0;
+        for (const addr of traders) {
+            rates = await portfolioSubHelper.getRates(addr, addr, AVAX, defaultMaker, defaultTaker);
+            expect(rates.maker).to.be.equal(expectedMakerRebateFromDefault[i]);
+            expect(rates.taker).to.be.equal(expectedTakerRebateFromDefault[i]);
+            //console.log(addr, rates.makerRate, rates.takerRate);
+            i++;
+        }
+
+        i = 0;
+        for (const addr of traders) {
+            rates = await portfolioSubHelper.getRates(addr, addr, ALOT, proposedMaker, proposedTaker);
+            expect(rates.maker).to.be.equal(expectedMakerRebateFromProposed[i]);
+            expect(rates.taker).to.be.equal(expectedTakerRebateFromProposed[i]);
+            //console.log(addr, rates.makerRate, rates.takerRate);
+            i++;
+        }
+
+        i = 0;
+        const takersVerySmall = [9, 5, 5]; // Based on 0 marker fee and only 1 bps(0.01%) taker fee =>  0.009%, 0.005%
+        for (const addr of traders) {
+            rates = await portfolioSubHelper.getRates(addr, addr, BTC, 0, 1);
+            expect(rates.maker).to.be.equal(0);
+            expect(rates.taker).to.be.equal(takersVerySmall[i]);
+            //console.log(addr, rates.makerRate, rates.takerRate);
+            i++;
+        }
+
+        // Delete volume rebate
+        await expect(portfolioSubHelper.addVolumeBasedRebates([trader1.address],  [0], [0]))
+        .to.emit(portfolioSubHelper, "RateChanged")
+        .withArgs("REBATES", "UPDATED", trader1.address, ethers.constants.HashZero, 0, 0);
+        rates = await portfolioSubHelper.getRates(trader1.address, trader1.address, BTC, 14, 20);
+        expect(rates.maker).to.be.equal(14 * 10);
+        expect(rates.taker).to.be.equal(20 * 10);
     })
-
-
-    it("Should remove convertible tokens correctly ", async () => {
-
-        // fail for non owner
-        await expect(portfolioSubHelper.connect(trader1).removeConvertibleToken(BTCb))
-            .to.be.revertedWith("AccessControl");
-
-        await portfolioSubHelper.removeConvertibleToken(ethers.constants.HashZero);
-
-        await portfolioSubHelper.removeConvertibleToken(BTCb);
-
-        expect( await portfolioSubHelper.getSymbolToConvert(BTCb)).to.be.equal(ethers.constants.HashZero);
-
-    })
-
 })


### PR DESCRIPTION
- Removed all March 24 conversion &  upgrade related code from PorftolioSub, PorftolioMain, InventoryManager & PortfolioBridgeSub & PortfolioSubHelper
- Native symbol can now be removed from PortfolioMain. In this case only the wrapped ERC20 version can be deposited. Native symbol removal restriction from PortfolioSub remains.
- Added volume based rebates to PortfolioSub Helper
- Changed Portfolio TENK=10000 to 100000 to support an extra digit of precision when applying volume based discounts
- Added destChainId to xfer.customdata in DelayedTransfers